### PR TITLE
Fix for dicebag test

### DIFF
--- a/tests/DiceBagTest.php
+++ b/tests/DiceBagTest.php
@@ -9,24 +9,27 @@ use LotGD\Core\DiceBag;
 * @backupGlobals disabled
 * @backupStaticAttributes disabled
 */
-class DiceBagTests extends \PHPUnit_Framework_TestCase {
-  public function testUniform() {
-    $db = new DiceBag();
-    $value = $db->uniform(0., 1.);
-    $this->assertGreaterThan(0, $value);
-    $this->assertLessThan(1, $value);
-  }
+class DiceBagTests extends \PHPUnit_Framework_TestCase
+{
+    public function testUniform()
+    {
+        $db = new DiceBag();
+        $value = $db->uniform(0., 1.);
+        $this->assertGreaterThanOrEqual(0, $value);
+        $this->assertLessThanOrEqual(1, $value);
+    }
 
-  public function testNormal() {
-    $db = new DiceBag();
-    $value = $db->normal(0., 1.);
-    $this->assertGreaterThan(0, $value);
-    $this->assertLessThan(1, $value);
+    public function testNormal()
+    {
+        $db = new DiceBag();
+        $value = $db->normal(0., 1.);
+        $this->assertGreaterThanOrEqual(0, $value);
+        $this->assertLessThanOrEqual(1, $value);
 
-    $value = $db->normal(1., 0.);
-    $this->assertGreaterThan(0, $value);
-    $this->assertLessThan(1, $value);
+        $value = $db->normal(1., 0.);
+        $this->assertGreaterThanOrEqual(0, $value);
+        $this->assertLessThanOrEqual(1, $value);
 
-    $this->assertEquals(0, $db->normal(0., 0.));
-  }
+        $this->assertEquals(0, $db->normal(0., 0.));
+    }
 }


### PR DESCRIPTION
dicebag tests asserts now for >= and <= instead of > and < since the edge
cases can happen from time to time as well.
