### PR TITLE
Add Module, ModuleManager and Event related classes.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ba904a6508c475cbab9d6d85a557a4fb",
+    "hash": "73cef680b614debf1a9900a0b9679fec",
     "content-hash": "f13234acbc23ca06e0181146f8aef31f",
     "packages": [
         {
@@ -841,7 +841,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.5",
+            "version": "v3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -1321,20 +1321,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -1358,7 +1361,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -2054,7 +2057,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.5",
+            "version": "v3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/EventHandler.php
+++ b/src/EventHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LotGD\Core;
+
+interface EventHandler
+{
+    /**
+     * Called when an event is published that is handled by this class.
+     *
+     * @param string $event Name of this event.
+     * @param array $context Arbitrary dictionary representing context around this event.
+     * @return array|null Return an array if you want to make changes to the $context before
+     * the next handler is called. Otherwise, return null.
+     */
+    public static function handleEvent(string $event, array $context): mixed;
+}

--- a/src/EventHandler.php
+++ b/src/EventHandler.php
@@ -10,7 +10,8 @@ interface EventHandler
      * @param string $event Name of this event.
      * @param array $context Arbitrary dictionary representing context around this event.
      * @return array|null Return an array if you want to make changes to the $context before
-     * the next handler is called. Otherwise, return null.
+     * the next handler is called. Otherwise, return null. Any changes made will be propogated
+     * to the event publisher as well.
      */
-    public static function handleEvent(string $event, array $context): mixed;
+    public static function handleEvent(string $event, array $context);
 }

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -19,6 +19,9 @@ class EventManager
 {
     private $em;
 
+    /**
+     * @param EntityManagerInterface $em The database entity manager.
+     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+use LotGD\Core\Models\EventSubscription;
+use LotGD\Core\EventHandler;
+use LotGD\Core\Excpetions\ClassNotFoundException;
+use LotGD\Core\Excpetions\SubscriptionNotFoundException;
+
+/**
+ * Manages a simple publish/subscribe system based on regular expressions
+ * matching event names and running a fixed
+ */
+class EventManager
+{
+    /**
+     * Publish an event. Will immediately cause handleEvent() to be called on all
+     * subscribed classes. This does not ensure any order in which the handlers
+     * are run.
+     *
+     * @param string $event The name of the event to publish.
+     */
+    public function publish(string $event, array $context)
+    {
+        // For right now, implement the naive approach of iterating every entry
+        // in the subscription database, checking the regular expression. We
+        // will need a cache :)
+        // TODO: Add an in-memory cache here. Will likely only be in the 1000s of
+        // patterns, so no need to go to the remote key-value store.
+
+        $subscriptions = EventSubscription::findAll();
+        foreach ($subscriptions as $s) {
+            if (preg_match($s->getPattern(), $event)) {
+                $class = $s->getClass();
+                $c = $class::handleEvent($event, $context);
+                if ($c !== null) {
+                    $context = $c;
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a new event subscription, registering $class to receive the handleEvent()
+     * method every time an event matching $pattern is published.
+     *
+     * @param string $pattern Regular expression, in PHP format, to match against
+     * published event names.
+     * @param string $class Fully qualified class name, which implements the
+     * EventHandler interface, that will receive the handleEvent() method call when
+     * events matching $pattern are published.
+     * @throws ClassNotFoundException if class cannot be resolved into a class.
+     * @throws WrongTypeException if class does not implement the EventHandler
+     * interface or the pattern is not a valid regular expression.
+     */
+    public function subscribe(string $pattern, string $class)
+    {
+        try {
+            // Can we resolve this class?
+            $klass = new \ReflectionClass($class);
+        } catch (LogicException $Exception) {
+            // Currently we do the same thing on not found as on some other
+            // exception. Maybe we should do something different.
+            throw new ClassNotFoundException();
+        } catch (ReflectionException $Exception) {
+            throw new ClassNotFoundException();
+        }
+
+        // Check if the class implements EventHandler.
+        $interface = EventHandler::class;
+        if (!$klass->implementsInterface($interface)) {
+            throw new WrongTypeException("Class does not implement {$interface}");
+        }
+
+        // Validate the regular expression.
+        if (preg_match($pattern, null) === false) {
+            throw new WrontTypeException('Invalid regular expression');
+        }
+
+        EventSubscription::create([
+            'pattern' => $pattern,
+            'class' => $class
+        ]);
+    }
+
+    /**
+     * Remove an event subscription, unregistering $class to receive the handleEvent()
+     * method when $pattern is published.
+     *
+     * @param string $pattern Regular expression, in PHP format, to match against
+     * published event names.
+     * @param string $class Fully qualified class name.
+     * @throws SubscriptionNotFoundException if the specified subscription does not exist.
+     */
+    public function unsubscribe(string $pattern, string $class)
+    {
+        EventSubscriotion::delete([
+            'pattern' => $pattern,
+            'class' => $class
+        ]);
+    }
+}

--- a/src/Exceptions/ModuleAlreadyExistsException.php
+++ b/src/Exceptions/ModuleAlreadyExistsException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace LotGD\Core\Exceptions;
 
 /**
- * Exception if a module does not exists.
+ * Exception if a module already exists.
  */
-class ModuleDoesNotExistException extends CoreException {
+class ModuleAlreadyExistsException extends CoreException {
 
 }

--- a/src/Exceptions/ModuleAlreadyExistsException.php
+++ b/src/Exceptions/ModuleAlreadyExistsException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if a module does not exists.
+ */
+class ModuleDoesNotExistException extends CoreException {
+
+}

--- a/src/Exceptions/ModuleDoesNotExistException.php
+++ b/src/Exceptions/ModuleDoesNotExistException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if a module already exists.
+ */
+class ModuleAlreadyExistsException extends CoreException {
+
+}

--- a/src/Exceptions/ModuleDoesNotExistException.php
+++ b/src/Exceptions/ModuleDoesNotExistException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace LotGD\Core\Exceptions;
 
 /**
- * Exception if a module already exists.
+ * Exception if a module does not exists.
  */
-class ModuleAlreadyExistsException extends CoreException {
+class ModuleDoesNotExistException extends CoreException {
 
 }

--- a/src/Exceptions/SubscriptionNotFoundException.php
+++ b/src/Exceptions/SubscriptionNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if an event subscription does not exist.
+ */
+class SubscriptionNotFoundException extends CoreException {
+
+}

--- a/src/Game.php
+++ b/src/Game.php
@@ -1,0 +1,28 @@
+<?php
+declare (strict_types=1);
+
+namespace LotGD\Core;
+
+class Game implements GameInterface
+{
+    private $entityManager;
+    private $eventManager;
+
+    /**
+     * Returns the game's entity manager.
+     * @return EntityManagerInterface The game's database entity manager.
+     */
+    public function getEntityManager()
+    {
+        return $this->entityManager;
+    }
+
+    /**
+     * Returns the game's event manager.
+     * @return EventManager The game's event manager.
+     */
+    public function getEventManager()
+    {
+        return $this->eventManager;
+    }
+}

--- a/src/GameInterface.php
+++ b/src/GameInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare (strict_types=1);
+
+namespace LotGD\Core;
+
+interface GameInterface
+{
+    /**
+     * @{inheritdoc}
+     */
+    public function getEntityManager();
+
+    /**
+    * @{inheritdoc}
+     */
+    public function getEventManager();
+}

--- a/src/Models/EventSubscription.php
+++ b/src/Models/EventSubscription.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models;
+
+use Doctrine\ORM\EntityManagerInterface;
+use LotGD\Core\Tools\Model\Creator;
+use LotGD\Core\Tools\Model\Deletor;
+
+/**
+ * An event name to class binding that represents that class listening for that
+ * event.
+ * @Entity
+ * @Table(name="event_subscriptions")
+ */
+class EventSubscription
+{
+    use Creator;
+    use Deletor;
+
+    /** @Id @Column(type="string"); */
+    private $pattern;
+
+    /** @Id @Column(type="string"); */
+    private $class;
+
+    /** @var array */
+    private static $fillable = [
+        "pattern",
+        "class",
+    ];
+
+    /**
+     * Returns the pattern used to match against event names for this subscription.
+     * Format is PHP regular expressions.
+     * @return string
+     */
+    public function getPattern(): string
+    {
+        return $this->pattern;
+    }
+
+    /**
+     * Returns the class name subscribed to this event.
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+}

--- a/src/Models/EventSubscription.php
+++ b/src/Models/EventSubscription.php
@@ -40,6 +40,11 @@ class EventSubscription
         return $this->pattern;
     }
 
+    public function setPattern(string $pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
     /**
      * Returns the class name subscribed to this event.
      * @return string
@@ -47,5 +52,10 @@ class EventSubscription
     public function getClass(): string
     {
         return $this->class;
+    }
+
+    public function setClass(string $class)
+    {
+        $this->class = $class;
     }
 }

--- a/src/Models/EventSubscription.php
+++ b/src/Models/EventSubscription.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace LotGD\Core\Models;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\Deletor;
 
@@ -13,7 +16,7 @@ use LotGD\Core\Tools\Model\Deletor;
  * @Entity
  * @Table(name="event_subscriptions")
  */
-class EventSubscription
+class EventSubscription implements CreateableInterface
 {
     use Creator;
     use Deletor;

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -22,7 +22,7 @@ class Module
     private $library;
 
     /** @Column(type="datetime") */
-    private $created;
+    private $createdAt;
 
     public function __construct(string $library)
     {
@@ -34,9 +34,9 @@ class Module
      * Returns the time this module was added to the system.
      * @return DateTime
      */
-    public function getCreated(): \DateTime
+    public function getCreatedAt(): \DateTime
     {
-        return $this->created;
+        return $this->createdAt;
     }
 
     /**

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models;
+
+use Doctrine\ORM\EntityManagerInterface;
+use LotGD\Core\Tools\Model\Creator;
+use LotGD\Core\Tools\Model\Deletor;
+
+/**
+ * An installed module in the system. Note that module metadata is stored in
+ * the composer.json for each module.
+ * @Entity
+ * @Table(name="modules")
+ */
+class Module
+{
+    use Creator;
+    use Deletor;
+
+    /** @Id @Column(type="string", unique=true); */
+    private $library;
+
+    /** @Column(type="datetime") */
+    private $created;
+
+    public function __construct(string $library)
+    {
+        $this->createdAt = new \DateTime();
+        $this->library = $library;
+    }
+
+    /**
+     * Returns the time this module was added to the system.
+     * @return DateTime
+     */
+    public function getCreated(): \DateTime
+    {
+        return $this->created;
+    }
+
+    /**
+     * Returns the library of this module, in the form 'vendor/project-name', usable
+     * by the Composer package manager.
+     * @return string
+     */
+    public function getLibrary(): string
+    {
+        return $this->library;
+    }
+}

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Models;
 
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
 use Doctrine\ORM\EntityManagerInterface;
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\Deletor;
@@ -13,7 +16,7 @@ use LotGD\Core\Tools\Model\Deletor;
  * @Entity
  * @Table(name="modules")
  */
-class Module
+class Module implements SaveableInterface
 {
     use Creator;
     use Deletor;

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -1,0 +1,87 @@
+<?php
+declare (strict_types=1);
+
+namespace LotGD\Core;
+
+use LotGD\Core\Models\Module;
+use LotGD\Core\Exceptions\ModuleAlreadyExistsException;
+use LotGD\Core\Exceptions\ModuleDoesNotExistException;
+use Composer\Package\PackageInterface;
+
+/**
+ * Handles the adding and removing of modules to the game.
+ */
+class ModuleManager
+{
+    private static function getPackageSubscriptions(PackageInterface $package)
+    {
+        $extra = $package->getExtra();
+        return $extra['subscriptions'];
+    }
+
+  /**
+   * Called when a module is added to the system. Performs setup tasks like
+   * registering the events this module responds to.
+   *
+   * @param string $library Name of the module, in 'vendor/module-name' format.
+   * @param PackageInterface $package Composer package containing this module.
+   * @throws ModuleAlreadyExistsException if the module is already installed.
+   * @throws ClassNotFoundException if an event subscription class cannot be resolved.
+   * @throws WrongTypeException if an event subscription class does not implement the EventHandler
+   * interface or the pattern is not a valid regular expression.
+   */
+    public static function register(string $library, PackageInterface $package)
+    {
+        $m = Module::find($library);
+        if ($m) {
+            throw new ModuleAlreadyExistsException($library);
+        } else {
+            // TODO: handle error cases here.
+            Module::create([
+            "library" => $library
+            ]);
+
+            EventManager $em = new EventManager();
+
+            // Subscribe to the module's events.
+            $subscriptions = ModuleManager::getPackageSubscriptions($package);
+            foreach ($subscriptions as $s) {
+                $pattern = $s['pattern'];
+                $class = $s['class'];
+
+                $em->subscribe($pattern, $class);
+            }
+        }
+    }
+
+  /**
+   * Called when a module is removed from the system. Performs teardown tasks like
+   * unregistering the events this module responds to.
+   *
+   * @param string $library Name of the module, in 'vendor/module-name' format.
+   * @throws ModuleDoesNotExistException if the module is not installed.
+   */
+    public static function unregister(string $library)
+    {
+        $m = Module::find($library);
+        if (!$m) {
+            throw new ModuleDoesNotExistException($library);
+        } else {
+            // TODO: handle error cases here.
+            $m->delete();
+
+            // Subscribe to the module's events.
+            $subscriptions = ModuleManager::getPackageSubscriptions($package);
+            foreach ($subscriptions as $s) {
+                $pattern = $s['pattern'];
+                $class = $s['class'];
+
+                try {
+                    $em->unsubscribe($pattern, $class);
+                } catch (SubscriptionNotFoundException $e) {
+                    // TODO: log this but continue on.
+                }
+            }
+        }
+    }
+}

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests;
+
+use LotGD\Core\EventManager;
+use LotGD\Core\Models\EventSubscription;
+use LotGD\Core\EventHandler;
+use LotGD\Core\Exceptions\WrongTypeException;
+use LotGD\Core\Exceptions\ClassNotFoundException;
+use LotGD\Core\Exceptions\SubscriptionNotFoundException;
+use LotGD\Core\Tests\ModelTestCase;
+
+class EventManagerTestInvalidSubscriber
+{
+
+}
+
+class EventManagerTestSubscriber implements EventHandler
+{
+    public static function handleEvent(string $event, array $context) {}
+}
+
+class EventManagerTestInstalledSubscriber implements EventHandler
+{
+    public static function handleEvent(string $event, array $context) {
+        $context['foo'] = 'baz';
+        return $context;
+    }
+}
+
+class EventManagerTest extends ModelTestCase
+{
+    /** @var string default data set */
+    protected $dataset = "eventManager";
+
+    public function testSubscribeNoClass()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $this->expectException(ClassNotFoundException::class);
+        $em->subscribe("/test.event/", 'LotGD\Core\Tests\NoClassHere');
+    }
+
+    public function testSubscribeInvalidClass()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $this->expectException(WrongTypeException::class);
+        $em->subscribe("/test.event/", 'LotGD\Core\Tests\EventManagerTestInvalidSubscriber');
+    }
+
+    public function testSubscribeInvalidRegexp()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $this->expectException(WrongTypeException::class);
+        $em->subscribe("/test.event", 'LotGD\Core\Tests\EventManagerTestSubscriber');
+    }
+
+    public function testGetSubscriptions()
+    {
+      $em = new EventManager($this->getEntityManager());
+
+      $pattern = "/test\\.foo.*/";
+      $class = 'LotGD\\Core\\Tests\\EventManagerTestInstalledSubscriber';
+
+      $sub = EventSubscription::create([
+          'pattern' => $pattern,
+          'class' => $class,
+      ]);
+
+      $subscriptions = $em->getSubscriptions();
+      $this->assertContainsOnlyInstancesOf(EventSubscription::class, $subscriptions);
+
+      // This is a little fragile, but assertContains() doesn't seem to work.
+      $this->assertEquals($sub, $subscriptions[0]);
+    }
+
+    public function testSubscribeSuccess()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $pattern = "/test.event/";
+        $class = 'LotGD\Core\Tests\EventManagerTestSubscriber';
+
+        $em->subscribe($pattern, $class);
+
+        $sub = EventSubscription::create([
+            'pattern' => $pattern,
+            'class' => $class,
+        ]);
+
+        $subscriptions = $em->getSubscriptions();
+        $this->assertContainsOnlyInstancesOf(EventSubscription::class, $subscriptions);
+
+        // This is a little fragile, but assertContains() doesn't seem to work.
+        $this->assertEquals($sub, $subscriptions[1]);
+    }
+
+    public function testUnsubscribeSuccess()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $em->unsubscribe("/test\\.foo.*/", 'LotGD\Core\Tests\EventManagerTestInstalledSubscriber');
+
+        $subscriptions = $em->getSubscriptions();
+        $this->assertEmpty($subscriptions);
+    }
+
+    public function testUnsubscribeNotFound()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $this->expectException(SubscriptionNotFoundException::class);
+        $em->unsubscribe("/notfound/", 'LotGD\Core\Tests\EventManagerTestInstalledSubscriber');
+    }
+
+    public function testPublish()
+    {
+        $em = new EventManager($this->getEntityManager());
+
+        $event = 'test.foo.something_here';
+        $context = array('foo' => 'bar');
+
+        $em->publish($event, $context);
+        $this->assertEquals($context['foo'], 'baz');
+    }
+}

--- a/tests/ModelTestCase.php
+++ b/tests/ModelTestCase.php
@@ -20,7 +20,7 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
     static private $em = null;
     /** @var \PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection */
     private $connection = null;
-    
+
     /**
      * Returns a connection to test models
      * @return \PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
@@ -30,15 +30,15 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
         if ($this->connection === null) {
             if (self::$pdo === null) {
                 self::$pdo = new \PDO($GLOBALS['DB_DSN'], $GLOBALS["DB_USER"], $GLOBALS["DB_PASSWORD"]);
-                
+
                 // Read db annotations from model files
                 $configuration = Setup::createAnnotationMetadataConfiguration(["src/Models"], true);
                 $configuration->setQuoteStrategy(new AnsiQuoteStrategy());
-                
+
                 $configuration->addFilter("soft-deleteable", 'Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter');
 
-                self::$em = EntityManager::create(["pdo" => self::$pdo], $configuration); 
-                self::$em->getFilters()->enable("soft-deleteable");   
+                self::$em = EntityManager::create(["pdo" => self::$pdo], $configuration);
+                self::$em->getFilters()->enable("soft-deleteable");
                 self::$em->getEventManager()->addEventSubscriber(new \Gedmo\SoftDeleteable\SoftDeleteableListener());
 
                 // Create Schema
@@ -46,16 +46,16 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
                 $schemaTool = new SchemaTool(self::$em);
                 $schemaTool->updateSchema($metaData);
             }
-            
-            $this->conn = $this->createDefaultDBConnection(self::$pdo, $GLOBALS["DB_NAME"]);
+
+            $this->connection = $this->createDefaultDBConnection(self::$pdo, $GLOBALS["DB_NAME"]);
         }
-        
+
         // It is important to clear the cache of the entity manager every time a new test runs!
         self::$em->clear();
-        
-        return $this->conn;
+
+        return $this->connection;
     }
-    
+
     /**
      * Returns a .yml dataset under this name
      * @return \PHPUnit_Extensions_Database_DataSet_YamlDataSet
@@ -66,7 +66,7 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
             __DIR__."/datasets/".$this->dataset.".yml"
         );
     }
-    
+
     /**
      * Returns the current entity manager
      * @return EntityManagerInterface
@@ -74,5 +74,12 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
     protected function getEntityManager(): EntityManagerInterface
     {
         return self::$em;
+    }
+
+    protected function tearDown() {
+        parent::tearDown();
+
+        // Clear out the cache so tests don't get confused.
+        $this->getEntityManager()->clear();
     }
 }

--- a/tests/Models/ModuleTest.php
+++ b/tests/Models/ModuleTest.php
@@ -23,7 +23,7 @@ class ModuleTest extends ModelTestCase
         $scene = $em->getRepository(Module::class)->find('lotgd/test');
 
         $this->assertEquals("lotgd/test", $scene->getLibrary());
-        $this->assertEquals(new \DateTime('2016-05-01'), $scene->getCreated());
+        $this->assertEquals(new \DateTime('2016-05-01'), $scene->getCreatedAt());
 
         $em->flush();
     }

--- a/tests/Models/ModuleTest.php
+++ b/tests/Models/ModuleTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests\Models;
+
+use LotGD\Core\Models\Module;
+use LotGD\Core\Tests\ModelTestCase;
+
+/**
+ * Tests for module management.
+ */
+class ModuleTest extends ModelTestCase
+{
+    /** @var string default data set */
+    protected $dataset = "module";
+
+    /**
+     * Test getter methods
+     */
+    public function testGetters()
+    {
+        $em = $this->getEntityManager();
+        $scene = $em->getRepository(Module::class)->find('lotgd/test');
+
+        $this->assertEquals("lotgd/test", $scene->getLibrary());
+        $this->assertEquals(new \DateTime('2016-05-01'), $scene->getCreated());
+
+        $em->flush();
+    }
+}

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -67,7 +67,9 @@ class ModuleManagerTest extends ModelTestCase
 
     public function testUnregisterWithNoEvents()
     {
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package = $this->getMockBuilder(PackageInterface::class)
+                        ->setMethods(['getExtra'])
+                        ->getMock();
         $package->method('getExtra')->willReturn(array());
 
         $eventManager = $this->getMockBuilder(EventManager::class)->getMock();
@@ -97,7 +99,9 @@ class ModuleManagerTest extends ModelTestCase
             ),
         );
 
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package = $this->getMockBuilder(PackageInterface::class)
+                        ->setMethods(['getExtra'])
+                        ->getMock();
         $package->method('getExtra')->willReturn(array(
             'subscriptions' => $subscriptions
         ));
@@ -137,7 +141,9 @@ class ModuleManagerTest extends ModelTestCase
             ),
         );
 
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package = $this->getMockBuilder(PackageInterface::class)
+                        ->setMethods(['getExtra'])
+                        ->getMock();
         $package->method('getExtra')->willReturn(array(
             'subscriptions' => $subscriptions
         ));
@@ -165,7 +171,9 @@ class ModuleManagerTest extends ModelTestCase
 
     public function testRegisterWithNoEvents()
     {
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+      $package = $this->getMockBuilder(PackageInterface::class)
+                      ->setMethods(['getExtra'])
+                      ->getMock();
         $package->method('getExtra')->willReturn(array());
 
         $eventManager = $this->getMockBuilder(EventManager::class)->getMock();
@@ -200,7 +208,9 @@ class ModuleManagerTest extends ModelTestCase
             ),
         );
 
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package = $this->getMockBuilder(PackageInterface::class)
+                        ->setMethods(['getExtra'])
+                        ->getMock();
         $package->method('getExtra')->willReturn(array(
             'subscriptions' => $subscriptions
         ));
@@ -245,7 +255,9 @@ class ModuleManagerTest extends ModelTestCase
             ),
         );
 
-        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package = $this->getMockBuilder(PackageInterface::class)
+                        ->setMethods(['getExtra'])
+                        ->getMock();
         $package->method('getExtra')->willReturn(array(
             'subscriptions' => $subscriptions
         ));

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -1,0 +1,278 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests;
+
+use LotGD\Core\Game;
+use LotGD\Core\EventHandler;
+use LotGD\Core\ModuleManager;
+use LotGD\Core\Models\Module;
+use LotGD\Core\Exceptions\ModuleAlreadyExistsException;
+use LotGD\Core\Exceptions\ModuleDoesNotExistException;
+use LotGD\Core\Tests\ModelTestCase;
+use Composer\Package\PackageInterface;
+
+class ModuleManagerTestSubscriber implements EventHandler
+{
+    public static function handleEvent(string $event, array $context) {}
+}
+
+class ModuleManagerTestAnotherSubscriber implements EventHandler
+{
+    public static function handleEvent(string $event, array $context) {}
+}
+
+class ModuleManagerTest extends ModelTestCase
+{
+    /** @var string default data set */
+    protected $dataset = "module";
+
+    public function testModuleAlreadyExists()
+    {
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $this->expectException(ModuleAlreadyExistsException::class);
+        $mm->register($game, 'lotgd/test', $package);
+    }
+
+    public function testGetModules()
+    {
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $modules = $mm->getModules();
+        $this->assertContainsOnlyInstancesOf(Module::class, $modules);
+
+        // This is a little fragile, but assertContains() doesn't seem to work.
+        $this->assertEquals(new \DateTime('2016-05-01'), $modules[0]->getCreatedAt());
+        $this->assertEquals('lotgd/test', $modules[0]->getLibrary());
+    }
+
+    public function testModuleDoesNotExist()
+    {
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $this->expectException(ModuleDoesNotExistException::class);
+        $mm->unregister($game, 'lotgd/no-module', $package);
+    }
+
+    public function testUnregisterWithNoEvents()
+    {
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array());
+
+        $eventManager = $this->getMockBuilder(EventManager::class)->getMock();
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->unregister($game, 'lotgd/test', $package);
+
+        $modules = $mm->getModules();
+        $this->assertEmpty($modules);
+    }
+
+    public function testUnregisterWithEvents()
+    {
+        $subscriptions = array(
+            array(
+                'pattern' => '/pattern1/',
+                'class' => 'SomeClass1'
+            ),
+            array(
+                'pattern' => '/pattern2/',
+                'class' => 'SomeClass2'
+            ),
+        );
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array(
+            'subscriptions' => $subscriptions
+        ));
+
+        $eventManager = $this->getMockBuilder(EventManager::class)
+                             ->setMethods(array('unsubscribe'))
+                             ->getMock();
+        $eventManager->expects($this->exactly(2))
+                     ->method('unsubscribe')
+                     ->withConsecutive(
+                         array($this->equalTo($subscriptions[0]['pattern']), $this->equalTo($subscriptions[0]['class'])),
+                         array($this->equalTo($subscriptions[1]['pattern']), $this->equalTo($subscriptions[1]['class']))
+                     );
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->unregister($game, 'lotgd/test', $package);
+
+        $modules = $mm->getModules();
+        $this->assertEmpty($modules);
+    }
+
+    public function testUnregisterWithInvalidEvents()
+    {
+        $subscriptions = array(
+            array(
+                'pattern' => '/pattern1/',
+                'class' => 'SomeClass1'
+            ),
+            array(
+                // Invalid subscription.
+                'crazy' => 'making'
+            ),
+        );
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array(
+            'subscriptions' => $subscriptions
+        ));
+
+        $eventManager = $this->getMockBuilder(EventManager::class)
+                             ->setMethods(array('unsubscribe'))
+                             ->getMock();
+        $eventManager->expects($this->exactly(1))
+                     ->method('unsubscribe')
+                     ->withConsecutive(
+                         array($this->equalTo($subscriptions[0]['pattern']), $this->equalTo($subscriptions[0]['class']))
+                     );
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->unregister($game, 'lotgd/test', $package);
+
+        $modules = $mm->getModules();
+        $this->assertEmpty($modules);
+    }
+
+    public function testRegisterWithNoEvents()
+    {
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array());
+
+        $eventManager = $this->getMockBuilder(EventManager::class)->getMock();
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->register($game, 'lotgd/test2', $package);
+
+        $modules = $mm->getModules();
+
+        // Timestamps should be within 5 seconds :)
+        $timeDiff = (new \DateTime())->getTimestamp() - $modules[1]->getCreatedAt()->getTimestamp();
+        $this->assertLessThanOrEqual(5, $timeDiff);
+        $this->assertGreaterThanOrEqual(-5, $timeDiff);
+        $this->assertEquals('lotgd/test2', $modules[1]->getLibrary());
+    }
+
+    public function testRegisterWithEvents()
+    {
+        $subscriptions = array(
+            array(
+                'pattern' => '/pattern1/',
+                'class' => ModuleManagerTestSubscriber::class
+            ),
+            array(
+                'pattern' => '/pattern2/',
+                'class' => ModuleManagerTestAnotherSubscriber::class
+            ),
+        );
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array(
+            'subscriptions' => $subscriptions
+        ));
+
+        $eventManager = $this->getMockBuilder(EventManager::class)
+                             ->setMethods(array('subscribe'))
+                             ->getMock();
+        $eventManager->expects($this->exactly(2))
+                     ->method('subscribe')
+                     ->withConsecutive(
+                         array($this->equalTo($subscriptions[0]['pattern']), $this->equalTo($subscriptions[0]['class'])),
+                         array($this->equalTo($subscriptions[1]['pattern']), $this->equalTo($subscriptions[1]['class']))
+                     );
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->register($game, 'lotgd/test2', $package);
+
+        $modules = $mm->getModules();
+
+        // Timestamps should be within 5 seconds :)
+        $timeDiff = (new \DateTime())->getTimestamp() - $modules[1]->getCreatedAt()->getTimestamp();
+        $this->assertLessThanOrEqual(5, $timeDiff);
+        $this->assertGreaterThanOrEqual(-5, $timeDiff);
+        $this->assertEquals('lotgd/test2', $modules[1]->getLibrary());
+    }
+
+    public function testRegisterWithInvalidEvents()
+    {
+        $subscriptions = array(
+            array(
+                'pattern' => '/pattern1/',
+                'class' => ModuleManagerTestSubscriber::class
+            ),
+            array(
+                // Invalid subscription.
+                'crazy' => 'making'
+            ),
+        );
+
+        $package = $this->getMockBuilder(PackageInterface::class)->getMock();
+        $package->method('getExtra')->willReturn(array(
+            'subscriptions' => $subscriptions
+        ));
+
+        $eventManager = $this->getMockBuilder(EventManager::class)
+                             ->setMethods(array('subscribe'))
+                             ->getMock();
+        $eventManager->expects($this->exactly(1))
+                     ->method('subscribe')
+                     ->withConsecutive(
+                         array($this->equalTo($subscriptions[0]['pattern']), $this->equalTo($subscriptions[0]['class']))
+                     );
+
+        $game = $this->getMockBuilder(Game::class)->getMock();
+        $game->method('getEntityManager')->willReturn($this->getEntityManager());
+        $game->method('getEventManager')->willReturn($eventManager);
+
+        $mm = new ModuleManager($this->getEntityManager());
+
+        $mm->register($game, 'lotgd/test2', $package);
+
+        $modules = $mm->getModules();
+
+        // Timestamps should be within 5 seconds :)
+        $timeDiff = (new \DateTime())->getTimestamp() - $modules[1]->getCreatedAt()->getTimestamp();
+        $this->assertLessThanOrEqual(5, $timeDiff);
+        $this->assertGreaterThanOrEqual(-5, $timeDiff);
+        $this->assertEquals('lotgd/test2', $modules[1]->getLibrary());
+    }
+}

--- a/tests/datasets/eventManager.yml
+++ b/tests/datasets/eventManager.yml
@@ -1,0 +1,4 @@
+event_subscriptions:
+    -
+        pattern: "/test\\.foo.*/"
+        class: "LotGD\\Core\\Tests\\EventManagerTestInstalledSubscriber"

--- a/tests/datasets/module.yml
+++ b/tests/datasets/module.yml
@@ -1,0 +1,4 @@
+modules:
+    -
+        library: "lotgd/test"
+        createdAt: "2016-05-01"


### PR DESCRIPTION
Add the basic concept of a Module, which is really just a pointer to the
composer-readable library name. We'll read the meta data from the
Composer API in a separate PR.

ModuleManager handles registering/unregistering modules, including
subscribing to events. Event subscriptions are managed via the
extra field in the module's composer.json and map regular expression
patterns representing event names to classes where `handleEvent()`
will be called.

Current format for the `handleEvent()` method will inevitably change.
