### PR TITLE
Adds complete and extended buff functionality

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "29eaae94cbc5b621aa6d3addeb2bb310",
+    "hash": "ae66861589f917620e6ca83a84e235cd",
     "content-hash": "cba343f753537b39dd63a0580b9c2630",
     "packages": [
         {
@@ -104,16 +104,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "48156b0fd9888bf528fbe9c9cba6963223cdd584"
+                "reference": "b2cf67b1a575d7e648c742be2454339232ef32b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/48156b0fd9888bf528fbe9c9cba6963223cdd584",
-                "reference": "48156b0fd9888bf528fbe9c9cba6963223cdd584",
+                "url": "https://api.github.com/repos/composer/composer/zipball/b2cf67b1a575d7e648c742be2454339232ef32b2",
+                "reference": "b2cf67b1a575d7e648c742be2454339232ef32b2",
                 "shasum": ""
             },
             "require": {
@@ -177,20 +177,20 @@
                 "dependency",
                 "package"
             ],
-            "time": "2016-05-17 11:25:44"
+            "time": "2016-05-31 18:48:12"
         },
         {
             "name": "composer/semver",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8"
+                "reference": "03c9de5aa25e7672c4ad251eeaba0c47a06c8b98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/84c47f3d8901440403217afc120683c7385aecb8",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8",
+                "url": "https://api.github.com/repos/composer/semver/zipball/03c9de5aa25e7672c4ad251eeaba0c47a06c8b98",
+                "reference": "03c9de5aa25e7672c4ad251eeaba0c47a06c8b98",
                 "shasum": ""
             },
             "require": {
@@ -239,7 +239,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-03-30 13:16:03"
+            "time": "2016-06-02 09:04:51"
         },
         {
             "name": "composer/spdx-licenses",
@@ -1776,16 +1776,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.3.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "44cd8e3930e431658d1a5de7d282d5cb37837fd5"
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/44cd8e3930e431658d1a5de7d282d5cb37837fd5",
-                "reference": "44cd8e3930e431658d1a5de7d282d5cb37837fd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
                 "shasum": ""
             },
             "require": {
@@ -1799,7 +1799,7 @@
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
@@ -1809,7 +1809,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -1835,7 +1835,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-27 16:24:29"
+            "time": "2016-06-03 05:03:56"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2020,16 +2020,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.3.4",
+            "version": "5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "00dd95ffb48805503817ced06399017df315fe5c"
+                "reference": "f5726a0262e5f74f8e9cf03128798b64160c441d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/00dd95ffb48805503817ced06399017df315fe5c",
-                "reference": "00dd95ffb48805503817ced06399017df315fe5c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f5726a0262e5f74f8e9cf03128798b64160c441d",
+                "reference": "f5726a0262e5f74f8e9cf03128798b64160c441d",
                 "shasum": ""
             },
             "require": {
@@ -2041,11 +2041,11 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^3.3.0",
+                "phpunit/php-code-coverage": "^4.0",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.1",
+                "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
@@ -2065,7 +2065,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "5.4.x-dev"
                 }
             },
             "autoload": {
@@ -2091,30 +2091,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-11 13:28:45"
+            "time": "2016-06-03 09:59:50"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.1.3",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "151c96874bff6fe61a25039df60e776613a61489"
+                "reference": "0dc8fd8e87e0366c22b6c25d1f43c4e2e66847b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/151c96874bff6fe61a25039df60e776613a61489",
-                "reference": "151c96874bff6fe61a25039df60e776613a61489",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/0dc8fd8e87e0366c22b6c25d1f43c4e2e66847b3",
+                "reference": "0dc8fd8e87e0366c22b6c25d1f43c4e2e66847b3",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.6",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -2122,7 +2125,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -2147,7 +2150,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-04-20 14:39:26"
+            "time": "2016-06-04 05:52:19"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Battle.php
+++ b/src/Battle.php
@@ -12,11 +12,12 @@ use LotGD\Core\{
     Exceptions\BattleNotOverException,
     Models\FighterInterface
 };
-use LotGD\Core\Models\BattleEvents\{
-    BuffMessageEvent,
-    CriticalHitEvent,
-    DamageEvent,
-    DeathEvent
+use LotGD\Core\Models\{
+    Buff,
+    BattleEvents\BuffMessageEvent,
+    BattleEvents\CriticalHitEvent,
+    BattleEvents\DamageEvent,
+    BattleEvents\DeathEvent
 };
 
 /**
@@ -40,6 +41,15 @@ class Battle
     protected $events;
     protected $result = 0;
     protected $round = 0;
+    
+    /**
+     * Battle Configuration
+     * @var type 
+     */
+    protected $configuration = [
+        "riposteEnabled" => true,
+        "levelAdjustementEnabled" => true,
+    ];
     
     public function __construct(Game $game, FighterInterface $player, FighterInterface $monster)
     {
@@ -65,12 +75,70 @@ class Battle
     }
     
     /**
-     * Returns true if the battle is over.
-     * @return type
+     * Disables ripostes
      */
-    public function isOver()
+    public function disableRiposte()
+    {
+        $this->configuration["riposteEnabled"] = false;
+    }
+    
+    /**
+     * Enables ripostes
+     */
+    public function enableRiposte()
+    {
+        $this->configuration["riposteEnabled"] = true;
+    }
+    
+    /**
+     * Returns true if ripostes are enabled
+     * @return bool
+     */
+    public function isRiposteEnabled(): bool
+    {
+        return $this->configuration["riposteEnabled"];
+    }
+    
+    public function enableLevelAdjustement()
+    {
+        $this->configuration["levelAdjustementEnabled"] = true;
+    }
+    
+    public function disableLevelAdjustement()
+    {
+        $this->configuration["levelAdjustementEnabled"] = false;
+    }
+    
+    public function isLevelAdjustementEnabled(): bool
+    {
+        return $this->configuration["levelAdjustementEnabled"];
+    }
+    
+    /**
+     * Returns true if the battle is over.
+     * @return bool
+     */
+    public function isOver(): bool
     {
         return $this->result !== self::RESULT_UNDECIDED;
+    }
+    
+    /**
+     * Returns the player instance
+     * @return FighterInterface
+     */
+    public function getPlayer(): FighterInterface
+    {
+        return $this->player;
+    }
+    
+    /**
+     * Returns the montser instance
+     * @return FighterInterface
+     */
+    public function getMonster(): FighterInterface
+    {
+        return $this->monster;
     }
     
     /**
@@ -87,7 +155,7 @@ class Battle
     }
     
     /**
-     * Returns the looser of this fight
+     * Returns the loser of this fight
      * @return FighterInterface
      */
     public function getLoser(): FighterInterface
@@ -136,15 +204,23 @@ class Battle
     {
         $damageHasBeenDone = false;
         
-        $playerBuffStartEvents = $this->player->getBuffs()->activate();
-        $monsterBuffStartEvents = $this->monster->getBuffs()->activate();
+        $this->player->getBuffs()->resetBuffUsage();
+        $this->monster->getBuffs()->resetBuffUsage();
+        
+        $playerBuffStartEvents = $this->player->getBuffs()->activate(Buff::ACTIVATE_ROUNDSTART);
+        $monsterBuffStartEvents = $this->monster->getBuffs()->activate(Buff::ACTIVATE_ROUNDSTART);
         
         do {
             $offenseTurnEvents = $firstDamageRound & self::DAMAGEROUND_PLAYER ? $this->turn($this->player, $this->monster) : new ArrayCollection();
             $defenseTurnEvents = $firstDamageRound & self::DAMAGEROUND_MONSTER ? $this->turn($this->monster, $this->player) : new ArrayCollection();
-
+            
             $events = new ArrayCollection(array_merge($offenseTurnEvents->toArray(), $defenseTurnEvents->toArray()));
             $eventsToAdd = new ArrayCollection();
+            
+            if ($this->player->getBuffs()->hasBuffsInUse() || $this->monster->getBuffs()->hasBuffsInUse()) {
+                // If there are active buffs, we still need to count the round even if there has not been any damage done.
+                $damageHasBeenDone = true;
+            }
 
             foreach($events as $event) {
                 $event->apply();
@@ -199,9 +275,42 @@ class Battle
         $attackersBuffs = $attacker->getBuffs();
         $defendersBuffs = $defender->getBuffs();
         
-        $attackersAttack = $attacker->getAttack($this->game);
-        $defendersDefense = $defender->getDefense($this->game);
+        // Adjustement makes fights versus monsters with lower level easier, 
+        // and more difficult if the monster has a higher level by adjusting
+        // the monster's defense value.
+        // For example, if a level 10 player attacks a level 9 monster, the 
+        // defenseAdjustement value for the monster is 0.81, reducing the monster's
+        // defense by 20% and making it more likely for the player to land a hit.
+        // On the other hand, the player's defense is increased by ~ 10%, making it 
+        // less likely for the enemy to hit the player.
+        $adjustement = 1.0;
+        $defenseAdjustement = 1.0;
+        if ($attacker === $this->player && $this->isLevelAdjustementEnabled()) {
+            if ($attacker->getLevel() > 1 && $defender->getLevel() > 1) {
+                $adjustement = $attacker->getLevel() / $defender->getLevel();
+                $defenseAdjustement = 1. / ($adjustement * $adjustement);
+            }
+        }
+        elseif ($defender === $this->player && $this->isLevelAdjustementEnabled()) {
+            if ($attacker->getLevel() > 1 && $defender->getLevel() > 1) {
+                $adjustement = $defender->getLevel() / $attacker->getLevel();
+                $defenseAdjustement = $adjustement;
+            }
+        }
         
+        // Apply buff scaling for the attacker's attack - this needs to take into
+        // account the attacker's goodguyAttackModifier and the defenders badguyAttackModifier
+        $attackersAttack = $attacker->getAttack($this->game)
+            * $attackersBuffs->getGoodguyAttackModifier()
+            * $defendersBuffs->getBadguyAttackModifier();
+        // It's the opposite for the defender's defense - it needs to take into account the
+        // defender's goodguyDefenseModifier as well as the attacker's badguyDefenseModifier.
+        $defendersDefense = $defender->getDefense($this->game) 
+            * $defendersBuffs->getGoodguyDefenseModifier() 
+            * $attackersBuffs->getBadguyDefenseModifier()
+            * $defenseAdjustement;
+        
+        // If the player is the attacker, we enable critical hits with a chance of 25%.
         if ($attacker === $this->game->getCharacter()) {
             // Players can land critical hits
             if ($this->game->getDiceBag()->chance(0.25)) {
@@ -209,21 +318,67 @@ class Battle
             }
         }
         
+        // Conversion from float to int, since the random number generator takes int values.
+        $attackersAttack = (int) round($attackersAttack, 0);
+        $defendersDefense = (int) round($defendersDefense, 0);
+        
+        // Lets roll the
         $attackersAtkRoll = $this->game->getDiceBag()->normal(0, $attackersAttack);
         $defendersDefRoll = $this->game->getDiceBag()->normal(0, $defendersDefense);
         $damage = $attackersAtkRoll - $defendersDefRoll;
         
-        if ($attackersAttack > $attacker->getAttack($this->game, true)) {
+        // If the attacker's attack after modification is bigger than before, 
+        // we call it a critical hit and apply the CriticalHitEvent.
+        if ($attackersAttack > $attacker->getAttack($this->game)) {
             $events->add(new CriticalHitEvent($attacker, $attackersAttack));
         }
         
-        if ($damage < 0) {
-            // RIPOSTE are only half as damaging than normal attacks
-            $damage /= 2;
+        // Set damage to 0 if riposte has been disabled
+        if ($this->isRiposteEnabled() === false && $damage < 0) {
+            $damage = 0;
         }
         
+        // Here, we take invulnurable buffs into account. There are 4 possible values coming from the 
+        // 2 buff lists, so we must take care a bit.
+        $attackerIsInvulnurable = $attackersBuffs->goodguyIsInvulnurable() || $defendersBuffs->badguyIsInvulnurable();
+        $defenderIsInvulnurable = $defendersBuffs->goodguyIsInvulnurable() || $attackersBuffs->badguyIsInvulnurable();
+        
+        if ($attackerIsInvulnurable && $defenderIsInvulnurable) {
+            // Both are invulnurable, damage is 0.
+            $damage = 0;
+        }
+        elseif ($attackerIsInvulnurable) {
+            // Attaker is invulnurable, damage is always > 0 (there is no riposte)
+            $damage = abs($damage);
+        }
+        elseif ($defenderIsInvulnurable) {
+            // Defender is invulnurable, damage is always < 0 (defender always ripostes)
+            $damage = - abs($damage);
+        }
+        
+        if ($damage < 0) {
+            // If the damage is less then 0, it's a RIPOSTE. They are only half 
+            // as damaging than normal attacks.
+            $damage /= 2;
+            
+            // Apply damage modification. It's a RIPOSTE, so the defenders makes the 
+            // damage. Therefore, we take defender's goodguyDamageModifier into account, 
+            // and the attacker's badguyDamageModifier.
+            $damage *= $defendersBuffs->getGoodguyDamageModifier()
+                * $attackersBuffs->getBadguyDamageModifier();
+        }
+        else {
+            // Apply damage modification. It's a normal attack - meaning the attacker does
+            // the damage. Therefore, we take the attacker's goodguyDamageModifier and
+            // the defender's badguyDamageModifier into account.
+            $damage *= $attackersBuffs->getGoodguyDamageModifier()
+                * $defendersBuffs->getBadguyDamageModifier();
+        }
+        
+        // Round the damage value and convert to int.
         $damage = (int)round($damage, 0);
         
+        // Add the damage event
         $events->add(new DamageEvent($attacker, $defender, $damage));
         
         return $events;

--- a/src/BuffList.php
+++ b/src/BuffList.php
@@ -8,11 +8,15 @@ use Doctrine\Common\Collections\{
     Collection
 };
 
+use LotGD\Core\Exceptions\{
+    ArgumentException
+};
 use LotGD\Core\Models\{
     Buff,
     Character,
     BattleEvents\BuffMessageEvent
 };
+
 
 /**
  * Description of BuffList
@@ -21,27 +25,46 @@ class BuffList
 {
     protected $buffs;
     protected $buffsBySlot;
-    protected $activeBuffs;
+    protected $activeBuffs = [];
+    /** @var Doctrine\Common\Collections\ArrayCollection */
+    protected $usedBuffs;
     
-    protected $activated = false;
+    /** @var boolean True of the modifiers have already been calculated */
+    protected $modifiersCalculated = false;
+    /** @var boolean True if the badguy is invulnurable */
     protected $badguyInvulnurable = false;
-    protected $badguyDamageModifier = 1;
-    protected $badguyAttackModifier = 1;
-    protected $badguyDefenseModifier = 1;
+    /** @var float */
+    protected $badguyDamageModifier = 1.;
+    /** @var float */
+    protected $badguyAttackModifier = 1.;
+    /** @var float */
+    protected $badguyDefenseModifier = 1.;
+    /** @var boolean True if the goodguy is invulnurable */
     protected $goodguyInvulnurable = false;
-    protected $goodguyDamageModifier = 1;
-    protected $goodguyAttackModifier = 1;
-    protected $goodguyDefenseModifier = 1;
+    /** @var float */
+    protected $goodguyDamageModifier = 1.;
+    /** @var float */
+    protected $goodguyAttackModifier = 1.;
+    /** @var float */
+    protected $goodguyDefenseModifier = 1.;
     
     protected $events;
     protected $loaded = false;
     
+    /**
+     * Initiates some variables
+     * @param Collection $buffs
+     */
     public function __construct(Collection $buffs)
     {
         $this->buffs = $buffs;
         $this->events = new ArrayCollection();
+        $this->usedBuffs = new ArrayCollection();
     }
     
+    /**
+     * Loads all buffs (since it's a lazy correlation)
+     */
     public function loadBuffs()
     {
         if ($this->loaded === false) {
@@ -51,50 +74,126 @@ class BuffList
         }
     }
     
-    public function activate(): Collection
+    /**
+     * Returns true if the given buff has already been used this round.
+     * @param Buff $buff
+     * @return bool
+     */
+    protected function hasBuffBeenUsed(Buff $buff): bool
     {
-        if ($this->activated === true) {
-            throw new BuffListAlreadyActivatedException("You can activate the buff list only once.");
+        if ($this->usedBuffs->contains($buff)) {
+            $used = true;
+        }
+        else {
+            $used = false;
         }
         
-        $this->activeBuffs = new ArrayCollection();
+        return $used;
+    }
+    
+    /**
+     * Marks the given buff as used
+     * @param Buff $buff
+     */
+    protected function useBuff(Buff $buff)
+    {
+        $this->usedBuffs->add($buff);
+    }
+    
+    /**
+     * Returns the buff's start or round message
+     * @param Buff $buff
+     * @return string
+     */
+    protected function getBuffMessage(Buff $buff): string
+    {
+        $return = "";
+        $used = $this->hasBuffBeenUsed($buff);
+        if ($buff->hasBeenStarted() === false && $used === false) {
+            $return = $buff->getStartMessage();
+            $buff->setHasBeenStarted();
+        }
+        elseif($used === false) {
+            $return = $buff->getRoundMessage();
+        }
+        
+        return $return;
+    }
+    
+    /**
+     * Resets the buff usage for a new round
+     */
+    public function resetBuffUsage()
+    {
+        $this->activeBuffs = [];
+        $this->usedBuffs = new ArrayCollection();
+        $this->modifiersCalculated = false;
+    }
+    
+    public function hasBuffsInUse(): bool
+    {
+        return count($this->usedBuffs) > 0 ? true : false;
+    }
+    
+    /**
+     * Activates all buffs that activate upon the given activation parameter.
+     * @param int $activation
+     * @return Collection
+     * @throws ArgumentException
+     * @throws BuffListAlreadyActivatedException
+     */
+    public function activate(int $activation): Collection
+    {
+        if ($activation%2 !== 0 && $activation !== 1) {
+            throw new ArgumentException("You can only activate one activation type at a time.");
+        }
+        
+        if (!empty($this->activeBuffs[$activation])) {
+            throw new BuffListAlreadyActivatedException("You can activate the buff list for the given activation step only once.");
+        }
+        
+        $this->activeBuffs[$activation] = new ArrayCollection();
         $activationEvents = new ArrayCollection();
         
-        foreach ($this->buffs as $buff) {
-            // Only look at buffs that are activated in battle.
-            if ($buff->getsActivatedAt(Buff::ACTIVATE_NONE)) {
+        foreach ($this->iterateBuffList() as $buff) {
+            // Continue to next buff if the activation is not in this round.
+            if ($buff->getsActivatedAt($activation) === false) {
                 continue;
             }
             
-            $this->activeBuffs->add($buff);
-            
-            if ($buff->hasBeenStarted() === false) {
-                $activationMessage = $buff->getStartMessage();
-                if ($activationMessage !== "") {
-                    $activationEvents->add(new BuffMessageEvent($activationMessage));
-                }
-                $buff->setHasBeenStarted();
+            $this->activeBuffs[$activation]->add($buff);
+  
+            // Returns start or roundMessage if the buff has not been used yet.
+            $buffMessage = $this->getBuffMessage($buff);
+            if ($buffMessage !== "") {
+                $activationEvents->add(new BuffMessageEvent($buffMessage));
             }
-            else {
-                $roundMessage = $buff->getRoundMessage();
-                if ($roundMessage !== "") {
-                    $activationEvents->add(new BuffMessageEvent($roundMessage));
-                }
+            
+            // Needs to come at the end
+            if ($this->hasBuffBeenUsed($buff) === false) {
+                $this->useBuff($buff);
             }
         }
         
         return $activationEvents;
     }
     
+    /**
+     * Decreases the rounds left on all used buffs
+     * @return Collection A Collection containing expire messages (if there are any)
+     */
     public function expireOneRound(): Collection
     {
+        /* @var $endEvents Collection */
         $endEvents = new ArrayCollection();
         
-        foreach($this->activeBuffs as $buff) {
+        foreach($this->usedBuffs as $buff) {
+            /* @var $roundsLeft int */
             $roundsLeft = $buff->getRounds() - 1;
             $buff->setRounds($roundsLeft);
             
             if ($roundsLeft === 0) {
+                /* @var $endMessage string */
                 $endMessage = $buff->getEndMessage();
                 
                 if ($endMessage !== "") {
@@ -108,13 +207,22 @@ class BuffList
         return $endEvents;
     }
     
+    /**
+     * Removes a buff from the buff list.
+     * @param Buff $buff
+     */
     public function remove(Buff $buff)
     {
         unset($this->buffsBySlot[$buff->getSlot()]);
         $this->buffs->removeElement($buff);
-        $this->activeBuffs->removeElement($buff);
+        $this->usedBuffs->removeElement($buff);
     }
     
+    /**
+     * Adds a buff to the buff list, occupying the slot.
+     * @param Buff $buff
+     * @throws BuffSlotOccupiedException if the slot is already occupied. Use renew instead.
+     */
     public function add(Buff $buff)
     {
         $this->loadBuffs();
@@ -128,6 +236,10 @@ class BuffList
         $this->buffsBySlot[$buff->getSlot()] = $buff;
     }
     
+    /**
+     * Renews a buff.
+     * @param Buff $buff
+     */
     public function renew(Buff $buff)
     {
         $this->loadBuffs();
@@ -139,5 +251,134 @@ class BuffList
         
         $this->buffs->add($buff);
         $this->buffsBySlot[$buff->getSlot()] = $buff;
+    }
+    
+    /**
+     * Calculates all total modifiers
+     * @return type
+     */
+    protected function calculateModifiers()
+    {
+        if ($this->modifiersCalculated === true) {
+            return;
+        }
+        
+        $this->badguyAttackModifier = 1.;
+        $this->badguyDamageModifier = 1.;
+        $this->badguyDefenseModifier = 1.;
+        $this->badguyInvulnurable = false;
+        $this->goodguyAttackModifier = 1.;
+        $this->goodguyDamageModifier = 1.;
+        $this->goodguyDefenseModifier = 1.;
+        $this->goodguyInvulnurable = false;
+        
+        /* @var $buff \LotGD\Core\Model\Buff */
+        foreach ($this->iterateBuffList() as $buff) {
+            $this->badguyAttackModifier *= $buff->getBadguyAttackModifier();
+            $this->badguyDefenseModifier *= $buff->getBadguyDefenseModifier();
+            $this->badguyDamageModifier *= $buff->getBadguyDamageModifier();
+            $this->badguyInvulnurable = $this->badguyInvulnurable || $buff->badguyIsInvulnurable();
+            $this->goodguyAttackModifier *= $buff->getGoodguyAttackModifier();
+            $this->goodguyDefenseModifier *= $buff->getGoodguyDefenseModifier();
+            $this->goodguyDamageModifier *= $buff->getGoodguyDamageModifier();
+            $this->goodguyInvulnurable = $this->goodguyInvulnurable || $buff->goodguyIsInvulnurable();
+        }
+    }
+    
+    /**
+     * Iterates over every buff that gets activated at one point during a round.
+     * @return Generator|\LotGD\Core\Model\Buff[]
+     */
+    protected function iterateBuffList()
+    {
+        foreach ($this->buffs as $buff) {
+            // Only look at buffs that are activated in battle.
+            if ($buff->getsActivatedAt(Buff::ACTIVATE_NONE)) {
+                continue;
+            }
+            else {
+                yield $buff;
+            }
+        }
+    }
+    
+    /**
+     * Returns the badguy attack modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getBadguyAttackModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->badguyAttackModifier;
+    }
+    
+     /**
+     * Returns the badguy defense modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getBadguyDefenseModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->badguyDefenseModifier;
+    }
+    
+    /**
+     * Returns the badguy damage modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getBadguyDamageModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->badguyDamageModifier;
+    }
+    
+    /**
+     * Returns true if the badguy is invulnurable
+     * @return bool
+     */
+    public function badguyIsInvulnurable(): bool
+    {
+        $this->calculateModifiers();
+        return $this->badguyInvulnurable;
+    }
+    
+    /**
+     * Returns the badguy attack modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getGoodguyAttackModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->goodguyAttackModifier;
+    }
+    
+     /**
+     * Returns the badguy defense modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getGoodguyDefenseModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->goodguyDefenseModifier;
+    }
+    
+     /**
+     * Returns the badguy damage modifier calculated over the whole bufflist
+     * @return float
+     */
+    public function getGoodguyDamageModifier(): float
+    {
+        $this->calculateModifiers();
+        return $this->goodguyDamageModifier;
+    }
+    
+    /**
+     * Returns true if the goodguy is invulnurable
+     * @return bool
+     */
+    public function goodguyIsInvulnurable(): bool
+    {
+        $this->calculateModifiers();
+        return $this->goodguyInvulnurable;
     }
 }

--- a/src/BuffList.php
+++ b/src/BuffList.php
@@ -3,19 +3,141 @@ declare(strict_types=1);
 
 namespace LotGD\Core;
 
-use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\{
+    ArrayCollection,
+    Collection
+};
 
-use LotGD\Core\Models\Buff;
-use LotGD\Core\Models\Character;
+use LotGD\Core\Models\{
+    Buff,
+    Character,
+    BattleEvents\BuffMessageEvent
+};
 
 /**
  * Description of BuffList
  */
 class BuffList
 {
-    private $buffs;
+    protected $buffs;
+    protected $buffsBySlot;
+    protected $activeBuffs;
     
-    public function __construct(Collection $buffs) {
+    protected $activated = false;
+    protected $badguyInvulnurable = false;
+    protected $badguyDamageModifier = 1;
+    protected $badguyAttackModifier = 1;
+    protected $badguyDefenseModifier = 1;
+    protected $goodguyInvulnurable = false;
+    protected $goodguyDamageModifier = 1;
+    protected $goodguyAttackModifier = 1;
+    protected $goodguyDefenseModifier = 1;
+    
+    protected $events;
+    protected $loaded = false;
+    
+    public function __construct(Collection $buffs)
+    {
         $this->buffs = $buffs;
+        $this->events = new ArrayCollection();
+    }
+    
+    public function loadBuffs()
+    {
+        if ($this->loaded === false) {
+            foreach($this->buffs as $buff) {
+                $this->buffsBySlot[$buff->getSlot()] = $buff;
+            }
+        }
+    }
+    
+    public function activate(): Collection
+    {
+        if ($this->activated === true) {
+            throw new BuffListAlreadyActivatedException("You can activate the buff list only once.");
+        }
+        
+        $this->activeBuffs = new ArrayCollection();
+        $activationEvents = new ArrayCollection();
+        
+        foreach ($this->buffs as $buff) {
+            // Only look at buffs that are activated in battle.
+            if ($buff->getsActivatedAt(Buff::ACTIVATE_NONE)) {
+                continue;
+            }
+            
+            $this->activeBuffs->add($buff);
+            
+            if ($buff->hasBeenStarted() === false) {
+                $activationMessage = $buff->getStartMessage();
+                if ($activationMessage !== "") {
+                    $activationEvents->add(new BuffMessageEvent($activationMessage));
+                }
+                $buff->setHasBeenStarted();
+            }
+            else {
+                $roundMessage = $buff->getRoundMessage();
+                if ($roundMessage !== "") {
+                    $activationEvents->add(new BuffMessageEvent($roundMessage));
+                }
+            }
+        }
+        
+        return $activationEvents;
+    }
+    
+    public function expireOneRound(): Collection
+    {
+        $endEvents = new ArrayCollection();
+        
+        foreach($this->activeBuffs as $buff) {
+            $roundsLeft = $buff->getRounds() - 1;
+            $buff->setRounds($roundsLeft);
+            
+            if ($roundsLeft === 0) {
+                $endMessage = $buff->getEndMessage();
+                
+                if ($endMessage !== "") {
+                    $endEvents->add(new BuffMessageEvent($endMessage));
+                }
+                
+                $this->remove($buff);
+            }
+        }
+        
+        return $endEvents;
+    }
+    
+    public function remove(Buff $buff)
+    {
+        unset($this->buffsBySlot[$buff->getSlot()]);
+        $this->buffs->removeElement($buff);
+        $this->activeBuffs->removeElement($buff);
+    }
+    
+    public function add(Buff $buff)
+    {
+        $this->loadBuffs();
+        $slot = $buff->getSlot();
+        
+        if (isset($this->buffsBySlot[$buff->getSlot()])) {
+            throw new BuffSlotOccupiedException("The slot {$slot} is already occupied.");
+        }
+        
+        $this->buffs->add($buff);
+        $this->buffsBySlot[$buff->getSlot()] = $buff;
+    }
+    
+    public function renew(Buff $buff)
+    {
+        $this->loadBuffs();
+        $slot = $buff->getSlot();
+        
+        if (isset($this->buffsBySlot[$buff->getSlot()])) {
+            $this->buffs->removeElement($buff);
+        }
+        
+        $this->buffs->add($buff);
+        $this->buffsBySlot[$buff->getSlot()] = $buff;
     }
 }

--- a/src/Exceptions/BattleEventException.php
+++ b/src/Exceptions/BattleEventException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if a specific, required argument is missing
+ */
+class BattleEventException extends BattleException
+{
+    
+}

--- a/src/Exceptions/BuffListAlreadyActivatedException.php
+++ b/src/Exceptions/BuffListAlreadyActivatedException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if a specific, required argument is missing
+ */
+class BuffListAlreadyActivatedException extends CoreException
+{
+    
+}

--- a/src/Models/BasicEnemy.php
+++ b/src/Models/BasicEnemy.php
@@ -69,6 +69,19 @@ abstract class BasicEnemy implements FighterInterface
     }
     
     /**
+     * Sets the enemy's current health
+     * @param int $health
+     */
+    public function setHealth(int $health)
+    {
+        $this->health = $health;
+        
+        if ($this->health < 0) {
+            $this->health = 0;
+        }
+    }
+    
+    /**
      * Does damage to the entity.
      * @param int $damage
      */

--- a/src/Models/BattleEvents/BattleEvent.php
+++ b/src/Models/BattleEvents/BattleEvent.php
@@ -3,14 +3,22 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Models\BattleEvents;
 
+use LotGD\Core\Exceptions\BattleEventException;
+
 /**
  * BattleEvent
  */
 class BattleEvent
 {   
+    private $applied = false;
+    
     public function apply()
     {
+        if ($this->applied === true) {
+            throw new BattleEventException("Cannot apply an event more than once.");
+        }
         
+        $this->applied = true;
     }
     
     public function decorate(Game $game): string

--- a/src/Models/BattleEvents/BattleEvent.php
+++ b/src/Models/BattleEvents/BattleEvent.php
@@ -12,6 +12,10 @@ class BattleEvent
 {   
     private $applied = false;
     
+    /**
+     * Applies the event.
+     * @throws BattleEventException
+     */
     public function apply()
     {
         if ($this->applied === true) {
@@ -21,6 +25,12 @@ class BattleEvent
         $this->applied = true;
     }
     
+    /**
+     * Returns a string describing the event.
+     * @param \LotGD\Core\Models\BattleEvents\Game $game
+     * @return string
+     * @throws BattleEventException
+     */
     public function decorate(Game $game): string
     {
         if ($this->applied === false) {

--- a/src/Models/BattleEvents/BattleEvent.php
+++ b/src/Models/BattleEvents/BattleEvent.php
@@ -23,6 +23,10 @@ class BattleEvent
     
     public function decorate(Game $game): string
     {
+        if ($this->applied === false) {
+            throw new BattleEventException("Buff needs to get applied before decoration.");
+        }
+        
         return "";
     }
 }

--- a/src/Models/BattleEvents/BuffMessageEvent.php
+++ b/src/Models/BattleEvents/BuffMessageEvent.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models\BattleEvents;
+
+use LotGD\Core\Exceptions\BattleEventException;
+
+/**
+ * BattleEvent
+ */
+class BuffMessageEvent extends BattleEvent
+{   
+    private $message = "";
+    
+    public function __construct(string $message) {
+        $this->message = $message;
+    }
+    
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    
+    public function decorate(Game $game): string
+    {
+        return $message;
+    }
+}

--- a/src/Models/BattleEvents/DamageEvent.php
+++ b/src/Models/BattleEvents/DamageEvent.php
@@ -31,6 +31,8 @@ class DamageEvent extends BattleEvent
     
     public function apply()
     {
+        parent::apply();
+        
         if ($this->damage !== 0) {
             // Only damage the victim if there is an actual effect
             $victim = $this->damage > 0 ? $this->defender : $this->attacker;

--- a/src/Models/BattleEvents/DamageEvent.php
+++ b/src/Models/BattleEvents/DamageEvent.php
@@ -24,11 +24,20 @@ class DamageEvent extends BattleEvent
         $this->damage = $damage;
     }
     
+    /**
+     * Returns the damage that is applied in this fight.
+     * 
+     * If the damage is > 0, the damage is applied to the defender. If it's < 0, it's applied to the attacker.
+     * @return int
+     */
     public function getDamage(): int
     {
         return $this->damage;
     }
     
+    /**
+     * Applies the damage.
+     */
     public function apply()
     {
         parent::apply();
@@ -40,8 +49,15 @@ class DamageEvent extends BattleEvent
         }
     }
     
+    /**
+     * Returns a string describing the event.
+     * @param \LotGD\Core\Models\BattleEvents\Game $game
+     * @return string
+     */
     public function decorate(Game $game): string
     {
+        parent::decorate($game);
+        
         $attackersName = $this->attacker->getDisplayName();
         $defendersName = $this->defender->getDisplayName();
             

--- a/src/Models/BattleEvents/DamageLifetapEvent.php
+++ b/src/Models/BattleEvents/DamageLifetapEvent.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models\BattleEvents;
+
+use LotGD\Core\Models\FighterInterface;
+
+/**
+ * BattleEvent
+ */
+class DamageLifetapEvent extends BattleEvent
+{   
+    /** @var \LotGD\Core\Models\FighterInterface */
+    protected $target;
+    /** @var int */
+    protected $healAmount;
+    /** @var string */
+    protected $message;
+            
+    public function __construct(FighterInterface $target, int $healAmount, string $message)
+    {
+        $this->target = $target;
+        $this->healAmount = $healAmount;
+        $this->message = $message;
+    }
+    
+    public function getHealAmount(): int
+    {
+        return $this->healAmount;
+    }
+    
+    public function apply()
+    {
+        parent::apply();
+        
+        if ($this->healAmount === 0) {
+            return;
+        } elseif ($this->healAmount > 0) {
+            $this->target->setHealth($this->target->getHealth() + $this->healAmount);
+        } else {
+            $this->target->setHealth($this->target->getHealth() + $this->healAmount);
+        }
+    }
+    
+    public function decorate(Game $game): string
+    {
+        parent::decorate($game);
+        
+        return str_replace(
+            [
+                "{target}", 
+                "{damage}"
+            ],
+            [
+                $this->target->getDisplayName(),
+                $this->healAmount,
+            ],
+            $this->message
+        );
+    }
+}

--- a/src/Models/BattleEvents/DamageReflectionEvent.php
+++ b/src/Models/BattleEvents/DamageReflectionEvent.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models\BattleEvents;
+
+use LotGD\Core\Models\FighterInterface;
+
+/**
+ * BattleEvent
+ */
+class DamageReflectionEvent extends BattleEvent
+{   
+    /** @var \LotGD\Core\Models\FighterInterface */
+    protected $target;
+    /** @var int */
+    protected $damage;
+    /** @var string */
+    protected $message;
+            
+    public function __construct(FighterInterface $target, int $damage, string $message)
+    {
+        $this->target = $target;
+        $this->damage = $damage;
+        $this->message = $message;
+    }
+    
+    /**
+     * Returns the damage
+     * @return int
+     */
+    public function getDamage(): int
+    {
+        return $this->damage;
+    }
+    
+    /*
+     * Applies the damage
+     */
+    public function apply()
+    {
+        parent::apply();
+        
+        if ($this->damage === 0) {
+            return;
+        } elseif ($this->damage > 0) {
+            $this->target->setHealth($this->target->getHealth() - $this->damage);
+        } else {
+            $this->target->setHealth($this->target->getHealth() - $this->damage);
+        }
+    }
+    
+    /**
+     * Returns a string describing the event
+     * @param \LotGD\Core\Models\BattleEvents\Game $game
+     * @return string
+     */
+    public function decorate(Game $game): string
+    {
+        parent::decorate($game);
+        
+        return str_replace(
+            [
+                "{target}", 
+                "{damage}"
+            ],
+            [
+                $this->target->getDisplayName(),
+                $this->damage,
+            ],
+            $this->message
+        );
+    }
+}

--- a/src/Models/BattleEvents/MinionDamageEvent.php
+++ b/src/Models/BattleEvents/MinionDamageEvent.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models\BattleEvents;
+
+use LotGD\Core\Exceptions\BattleEventException;
+use LotGD\Core\Models\FighterInterface;
+
+/**
+ * BattleEvent
+ */
+class MinionDamageEvent extends BattleEvent
+{
+    protected $target;
+    protected $damage;
+    protected $message;
+    
+    public function __construct(
+        FighterInterface $target,
+        int $damage,
+        string $message
+    ) {
+        $this->target = $target;
+        $this->damage = $damage;
+        $this->message = $message;
+    }
+    
+    public function decorate(Game $game): string
+    {
+        parent::decorate();
+        
+        return str_replace(
+            [
+                "{target}",
+                "{amount}",
+            ],
+            [
+                $this->target->getDisplayName(),
+                $this->damage,
+            ],
+            $this->message
+        );
+    }
+    
+    public function apply()
+    {
+        parent::apply();
+        $this->target->setHealth($this->target->getHealth() - $this->damage);
+    }
+}

--- a/src/Models/BattleEvents/RegenerationBuffEvent.php
+++ b/src/Models/BattleEvents/RegenerationBuffEvent.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models\BattleEvents;
+
+use LotGD\Core\Exceptions\BattleEventException;
+use LotGD\Core\Models\FighterInterface;
+
+/**
+ * BattleEvent
+ */
+class RegenerationBuffEvent extends BattleEvent
+{
+    protected $target;
+    protected $regeneration;
+    protected $effectMessage;
+    protected $noEffectMessage;
+    
+    public function __construct(
+        FighterInterface $target,
+        int $regeneration,
+        string $effectMessage,
+        string $noEffectMessage
+    ) {
+        $this->target = $target;
+        $this->regeneration = $regeneration;
+        $this->effectMessage = $effectMessage;
+        $this->noEffectMessage = $noEffectMessage;
+    }
+    
+    public function decorate(Game $game): string
+    {
+        parent::decorate();
+        
+        if ($this->regeneration === 0) {
+            return str_replace(
+                "{target}",
+                $target->getDisplayName(),
+                $this->noEffectMessage
+            );
+        }
+        else {
+            return str_replace(
+                [
+                    "{target}",
+                    "{amount}"
+                ],
+                [
+                    $target->getDisplayName(),
+                    $this->regeneration,
+                ],
+                $this->effectMessage
+            );
+        }
+    }
+    
+    public function apply()
+    {
+        parent::apply();
+        
+        $healthLacking = $this->target->getMaxHealth() - $this->target->getHealth();
+        $healthLeft = $this->target->getHealth();
+        
+        if ($this->regeneration > 0) {
+            // Healing
+            if ($healthLacking === 0) {
+                $this->regeneration = 0;
+            }
+            elseif ($healthLacking < $this->regeneration) {
+                $this->regeneration = $healthLacking;
+            }
+        }
+        else {
+            // Damaging
+            if ($healthLeft === 0) {
+                $this->regeneration = 0;
+            }
+            elseif ($healthLeft < -1*$this->regeneration) {
+                $this->regeneration = - $healthLeft;
+            }
+        }
+        
+        $this->target->setHealth($this->target->getHealth() + $this->regeneration);
+    }
+}

--- a/src/Models/Buff.php
+++ b/src/Models/Buff.php
@@ -85,7 +85,7 @@ class Buff
      * @var int
      * @Column(type="integer")
      */
-    private $activateAt = self::ACTIVATE_NONE;
+    private $activateAt;
     /**
      * True if the buff survives a new day
      * @var bool
@@ -264,6 +264,7 @@ class Buff
     
     private $required = [
         "slot",
+        "activateAt",
     ];
     
     /**
@@ -310,11 +311,11 @@ class Buff
             }
             
             $this->{$attribute} = $value;
-            
-            foreach($this->required as $required) {
-                if (is_null($this->$required)) {
-                    throw new ArgumentException("{$required} needs to be inside of the buffArray!");
-                }
+        }
+        
+        foreach($this->required as $required) {
+            if (is_null($this->$required)) {
+                throw new ArgumentException("{$required} needs to be inside of the buffArray!");
             }
         }
     }
@@ -453,7 +454,7 @@ class Buff
             return $this->activateAt == self::ACTIVATE_NONE ? true : false;
         }
         else {
-            return ($this->activateAt & $flag > 0) === 1;
+            return ($this->activateAt & $flag) == true;
         }
     }
     

--- a/src/Models/Buff.php
+++ b/src/Models/Buff.php
@@ -119,13 +119,13 @@ class Buff
      */
     private $goodguyRegeneration = 0;
     /**
-     * Fraction of damage applied to the badguy that gets converted to health ("absorb")
+     * Fraction of damage applied to the badguy that gets converted to health ("absorb") for the goodguy
      * @var float
      * @Column(type="float")
      */
     private $badguyLifetap = 0;
     /**
-     * Fraction of damage applied to the goodguy that gets converted to health
+     * Fraction of damage applied to the goodguy that gets converted to health for the badguy
      * @var float
      * @Column(type="float")
      */
@@ -227,6 +227,10 @@ class Buff
      */
     private $hasBeenStarted = false;
     
+    /**
+     * Allowed buff values and their type
+     * @var array 
+     */
     private $buffArrayTemplate = [
         "slot" => "string",
         "name" => "string",
@@ -262,6 +266,10 @@ class Buff
         "goodguyInvulnurable" => "bool",
     ];
     
+    /**
+     * Requried buff values.
+     * @var type 
+     */
     private $required = [
         "slot",
         "activateAt",

--- a/src/Models/Buff.php
+++ b/src/Models/Buff.php
@@ -43,49 +43,49 @@ class Buff
      * @var string
      * @Column(type="text")
      */
-    private $startMessage;
+    private $startMessage = "";
     /**
      * The message given every round
      * @var string
      * @Column(type="text")
      */
-    private $roundMessage;
+    private $roundMessage = "";
     /**
      * The message given if the buff ends
      * @var string
      * @Column(type="text")
      */
-    private $endMessage;
+    private $endMessage = "";
     /**
      * The message given if the effect has success
      * @var string
      * @Column(type="text")
      */
-    private $effectSucceedsMessage;
+    private $effectSucceedsMessage = "";
     /**
      * The message given if the effect fails
      * @var string
      * @Column(type="text")
      */
-    private $effectFailsMessage;
+    private $effectFailsMessage = "";
     /**
      * The message given if the effect has no effect
      * @var string
      * @Column(type="text")
      */
-    private $noEffectMessage;
+    private $noEffectMessage = "";
     /**
      * Message that gets displayed every new day.
      * @var string
      * @Column(type="text")
      */
-    private $newDayMessage;
+    private $newDayMessage = "";
     /**
      * A value determining when the buffs activates
      * @var int
      * @Column(type="integer")
      */
-    private $activateAt;
+    private $activateAt = self::ACTIVATE_NONE;
     /**
      * True if the buff survives a new day
      * @var bool
@@ -293,7 +293,12 @@ class Buff
                     
                 case "float":
                     if (is_float($value) === false) {
-                        throw new ArgumentException("{$attribute} needs to be a float.");
+                        // Convert to float if it is an integer.
+                        if (is_int($value) === false) {
+                            throw new ArgumentException("{$attribute} needs to be a float.");
+                        }
+                        
+                        $value = (float)$value;
                     }
                     break;
                     
@@ -444,7 +449,12 @@ class Buff
      */
     public function getsActivatedAt(int $flag): bool
     {
-        return ($flag === self::ACTIVATE_NONE ? $this->activateAt === self::ACTIVATE_NONE : $this->activateAt & $flag);
+        if ($flag === self::ACTIVATE_NONE) {
+            return $this->activateAt == self::ACTIVATE_NONE ? true : false;
+        }
+        else {
+            return ($this->activateAt & $flag > 0) === 1;
+        }
     }
     
     /**
@@ -662,7 +672,7 @@ class Buff
      * Returns true if the goodguy is invulnurable
      * @return bool
      */
-    public function getGoodguyIsInvulnurable(): bool
+    public function goodguyIsInvulnurable(): bool
     {
         return $this->goodguyInvulnurable;
     }

--- a/src/Models/Character.php
+++ b/src/Models/Character.php
@@ -10,7 +10,10 @@ use Doctrine\Common\Collections\{
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
-use LotGD\Core\Game;
+use LotGD\Core\{
+    BuffList,
+    Game
+};
 use LotGD\Core\Tools\Exceptions\BuffSlotOccupiedException;
 use LotGD\Core\Tools\Model\{
     Creator,
@@ -61,6 +64,8 @@ class Character implements CharacterInterface, CreateableInterface
     private $messageThreads;
     /** @OneToMany(targetEntity="Buff", mappedBy="character", cascade={"persist"}) */
     private $buffs;
+    /** @var BuffList */
+    private $buffList;
     
     /** @var array */
     private static $fillable = [
@@ -258,7 +263,7 @@ class Character implements CharacterInterface, CreateableInterface
      */
     public function getBuffs(): BuffList
     {
-        $this->buffList ?? new BuffList($this->buffs);
+        $this->buffList = $this->buffList ?? new BuffList($this->buffs);
         return $this->buffList;
     }
     

--- a/src/Models/FighterInterface.php
+++ b/src/Models/FighterInterface.php
@@ -22,5 +22,6 @@ interface FighterInterface
     public function getDefense(Game $game, bool $ignoreBuffs = false): int;
     public function damage(int $damage);
     public function heal(int $heal);
+    public function setHealth(int $amount);
     public function getBuffs(): BuffList;
 }

--- a/src/Models/FighterInterface.php
+++ b/src/Models/FighterInterface.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Models;
 
-use LotGD\Core\Game;
+use LotGD\Core\{
+    BuffList,
+    Game
+};
 
 /**
  * Interface for models that should be able to participate in fights.
@@ -19,4 +22,5 @@ interface FighterInterface
     public function getDefense(Game $game, bool $ignoreBuffs = false): int;
     public function damage(int $damage);
     public function heal(int $heal);
+    public function getBuffs(): BuffList;
 }

--- a/src/Tools/Model/AutoScaleFighter.php
+++ b/src/Tools/Model/AutoScaleFighter.php
@@ -3,7 +3,12 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Tools\Model;
 
-use LotGD\Core\Game;
+use Doctrine\Common\Collections\ArrayCollection;
+
+use LotGD\Core\{
+    BuffList,
+    Game
+};
 
 /**
  * Automatically calculated values based on the fighter's level
@@ -38,5 +43,15 @@ trait AutoScaleFighter
     {
         $level = $this->getlevel();
         return (int)floor($level*1.45);
+    }
+    
+    /**
+     * Returns an empty bufflist
+     * @return BuffList
+     */
+    public function getBuffs(): BuffList
+    {
+        $this->buffList = $this->buffList ?? new BuffList(new ArrayCollection());
+        return $this->buffList;
     }
 }

--- a/src/Tools/Model/MockCharacter.php
+++ b/src/Tools/Model/MockCharacter.php
@@ -4,7 +4,10 @@ declare(strict_types = 1);
 
 namespace LotGD\Core\Tools\Model;
 
-use LotGD\Core\Game;
+use LotGD\Core\{
+    BuffList,
+    Game
+};
 use LotGD\Core\Exceptions\IsNullException;
 use LotGD\Core\Models\CharacterViewpoint;
 
@@ -80,5 +83,14 @@ trait MockCharacter
     public function getProperty(string $name, $default = null)
     {
         return $default;
+    }
+    
+    /**
+     * Returns an empty bufflist
+     * @return BuffList
+     */
+    public function getBuffs(): BuffList
+    {
+        throw new IsNullException();
     }
 }

--- a/src/Tools/Model/MockCharacter.php
+++ b/src/Tools/Model/MockCharacter.php
@@ -40,6 +40,11 @@ trait MockCharacter
         throw new IsNullException();
     }
     
+    public function setHealth(int $amount)
+    {
+        throw new IsNullException();
+    }
+    
     public function damage(int $damage)
     {
         throw new IsNullException();

--- a/tests/BattleTest.php
+++ b/tests/BattleTest.php
@@ -17,6 +17,8 @@ use LotGD\Core\Models\BattleEvents\{
     BuffMessageEvent,
     CriticalHitEvent,
     DamageEvent,
+    DamageLifetapEvent,
+    DamageReflectionEvent,
     DeathEvent,
     MinionDamageEvent,
     RegenerationBuffEvent
@@ -681,6 +683,450 @@ class BattleTest extends ModelTestCase
             // Round 3
             DamageEvent::class,
             DamageEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleGoodguyDamageReflectionBuff()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "goodguyDamageReflection" => 10,
+            "effectSucceedsMessage" => "Damage is reflected to you! You take {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 1);
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        $battle->disableCriticalHit();
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleGoodguyDamageReflectionBuffNegative()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "goodguyDamageReflection" => -100,
+            "effectSucceedsMessage" => "Damage is reflected to you! You heal {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 3);
+        
+        $battle->disableCriticalHit();
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertGreaterThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleBadguyDamageReflectionBuff()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "badguyDamageReflection" => 10,
+            "effectSucceedsMessage" => "Damage is reflected to you! You take {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 1);
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        $battle->disableCriticalHit();
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleBadguyDamageReflectionBuffNegative()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "badguyDamageReflection" => -100,
+            "effectSucceedsMessage" => "Damage is reflected to you! You heal {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 4);
+        
+        $battle->disableCriticalHit();
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        $this->assertGreaterThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+            DamageEvent::class,
+            DamageReflectionEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleGoodguyDamageLifetapBuff()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "goodguyLifetap" => 100,
+            "effectSucceedsMessage" => "{target} absorbs {amount} done to you!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSED!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 3);
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        $battle->disableCriticalHit();
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleGoodguyDamageLifetapBuffNegative()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "badguyLifetap" => -10,
+            "effectSucceedsMessage" => "Damage is reflected to you! You heal {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 1);
+        
+        $battle->disableCriticalHit();
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleBadguyDamageLifetapBuff()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "badguyLifetap" => 100,
+            "effectSucceedsMessage" => "Damage is reflected to you! You take {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 4);
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        $battle->disableCriticalHit();
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertGreaterThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+        ];
+        
+        $numOfEvents = count($expectedEvents);
+        for ($i = 0; $i < $numOfEvents; $i++) {
+            $this->assertInstanceOf($expectedEvents[$i], $battle->getEvents()[$i]);
+        }
+    }
+    
+    public function testBattleBadguyDamageLifetapBuffNegative()
+    {
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 5,
+            "badguyLifetap" => -10,
+            "effectSucceedsMessage" => "Damage is reflected to you! You heal {damage} damage!",
+            "effectFailsMessage" => "The damage reflection fails since you RIPOSE!",
+            "noEffectMessage" => "There is no damage to reflect.",
+            "activateAt" => Buff::ACTIVATE_WHILEROUND,
+        ]), 1);
+        
+        $battle->disableCriticalHit();
+        
+        $battle->getPlayer()->setHealth(10000);
+        $battle->getMonster()->setHealth(10000);
+        
+        $battle->fightNRounds(5);
+        
+        $this->assertLessThanOrEqual(10000, $battle->getMonster()->getHealth());
+        $this->assertLessThanOrEqual(10000, $battle->getPlayer()->getHealth());
+        
+        $expectedEvents = [
+            // Round 1
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 2
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 3
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 4
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            // Round 5
+            DamageEvent::class,
+            DamageLifetapEvent::class,
+            DamageEvent::class,
+            DamageLifetapEvent::class,
         ];
         
         $numOfEvents = count($expectedEvents);

--- a/tests/BattleTest.php
+++ b/tests/BattleTest.php
@@ -121,9 +121,9 @@ class BattleTest extends ModelTestCase
     }
     
     /**
-     * Tests a fight which the player has to loose (lvl 1 vs lvl 100)
+     * Tests a fight which the player has to lose (lvl 1 vs lvl 100)
      */
-    public function testPlayerLooseBattle()
+    public function testPlayerLoseBattle()
     {
         $em = $this->getEntityManager();
         
@@ -171,7 +171,7 @@ class BattleTest extends ModelTestCase
     /**
      * @expectedException LotGD\Core\Exceptions\BattleNotOverException
      */
-    public function testBattleNotOverExceptionFromLooser()
+    public function testBattleNotOverExceptionFromLoser()
     {
         $em = $this->getEntityManager();
         
@@ -196,25 +196,54 @@ class BattleTest extends ModelTestCase
         
         $battle = new Battle($this->getMockGame($character), $character, $monster);
         
-        // Fighting for 99 rounds should be enough for determining a looser - and to
+        // Fighting for 99 rounds should be enough for determining a loser - and to
         // throw the exception.
         for ($n = 0; $n < 99; $n++) {
             $battle->fightNRounds(1);
         }
     }
     
-    private function provideBuffBattleParticipants(Buff $buff): Battle
+    private function provideBuffBattleParticipants(Buff $buff, int $participantsType): Battle
     {
         $em = $this->getEntityManager();
+        $em->clear();
         
-        $character = $em->getRepository(Character::class)->find(4);
-        $monster = $em->getRepository(Monster::class)->find(3);
+        switch ($participantsType) {
+            default:
+            case 0:
+                // Fair Battle
+                $character = $em->getRepository(Character::class)->find(1);
+                $monster = $em->getRepository(Monster::class)->find(1);
+                break;
+            case 1:
+                // very long battle
+                $character = $em->getRepository(Character::class)->find(4);
+                $monster = $em->getRepository(Monster::class)->find(3);
+                break;
+            case 2:
+                // player should win battle
+                $character = $em->getRepository(Character::class)->find(13);
+                $monster = $em->getRepository(Monster::class)->find(11);
+                break;
+            case 3:
+                // player should lose battle
+                $character = $em->getRepository(Character::class)->find(11);
+                $monster = $em->getRepository(Monster::class)->find(13);
+                break;
+        }
         
         $character->addBuff($buff);
         
         return new Battle($this->getMockGame($character), $character, $monster);
     }
     
+    /**
+     * Asserts that a certain BuffMessageEvent with a specific text is contained in the lst of events
+     * @param Collection $events The list of events
+     * @param string $battleEventText The text to test for
+     * @param int $timesAtLeast Mininum number of times the message is expected to be in the event list
+     * @param int? $timesAtMax Maximum number of times the message is expected to be in the event list, or $timesAtLeast if null.
+     */
     protected function assertBuffEventMessageExists(
         Collection $events, 
         string $battleEventText, 
@@ -238,6 +267,10 @@ class BattleTest extends ModelTestCase
         $this->assertLessThanOrEqual($timesAtMax, $eventCounter);
     }
     
+    /**
+     * Tests normal buff messages - message upon start of the buff, message every 
+     * round (except when it's started), and the message displayed if the buff expires.
+     */
     public function testBattleBuffMessages()
     {
         $battle = $this->provideBuffBattleParticipants(new Buff([
@@ -247,8 +280,9 @@ class BattleTest extends ModelTestCase
             "roundMessage" => "The buff is still activate",
             "endMessage" => "The buff is ending.",
             "activateAt" => Buff::ACTIVATE_ROUNDSTART,
-        ]));
+        ]), 1);
         
+        // We fight for 5 rounds - this ensures that the buff is started and expired.
         $battle->fightNRounds(5);
         
         $this->assertBuffEventMessageExists($battle->getEvents(), "And this buff starts!", 1);
@@ -278,4 +312,291 @@ class BattleTest extends ModelTestCase
         }
     }
             
+    public function testBattleBuffPlayerGoodguyModifier()
+    {
+        // Get a battle ready
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "goodguyAttackModifier" => 0.0,
+            "goodguyDefenseModifier" => 0.0,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 2);
+        
+        $rounds = $battle->fightNRounds(99);
+        
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getPlayer(), $battle->getLoser());
+        
+        // Get a battle that the player should lose and apply a buff that the player forces to win
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "goodguyAttackModifier" => 2,
+            "goodguyDefenseModifier" => 2,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 3);
+        
+        $battle->fightNRounds(99);
+        
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getPlayer(), $battle->getWinner());
+    }
+    
+    public function testBattleBuffPlayerBadguyModifier()
+    {
+        // Get a battle that the player should win and apply a buff that the player forces to lose.
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "badguyAttackModifier" => 10,
+            "badguyDefenseModifier" => 10,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 2);
+        
+        $rounds = $battle->fightNRounds(99);
+        
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getPlayer(), $battle->getLoser());
+        
+        // Get a battle that the player should lose and apply a buff that the player forces to win
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "badguyAttackModifier" => 0,
+            "badguyDefenseModifier" => 0,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 3);
+        
+        $battle->fightNRounds(99);
+        
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getPlayer(), $battle->getWinner());
+    }
+    
+    public function testBattleBuffPlayerDamageModifier()
+    {
+        // Get a battle that the player should win and apply a buff that the player forces to lose
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "goodguyDamageModifier" => 0.0,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 0);
+        
+        $rounds = $battle->fightNRounds(10);
+        
+        $this->assertSame($battle->getMonster()->getMaxHealth(), $battle->getMonster()->getHealth());
+        
+        // Get a battle that the player should lose and apply a buff that the player forces to win
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "badguyDamageModifier" => 0.0,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 0);
+        
+        $battle->fightNRounds(10);
+        
+        $this->assertSame($battle->getPlayer()->getMaxHealth(), $battle->getPlayer()->getHealth());
+    }
+    
+    public function testBattleBuffPlayerInvulnurability()
+    {
+        // Get a battle that the player should win and apply a buff that the player forces to lose
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "badguyInvulnurable" => true,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 0);
+        
+        $rounds = $battle->fightNRounds(99);
+        
+        $this->assertSame($battle->getMonster()->getMaxHealth(), $battle->getMonster()->getHealth());
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getMonster(), $battle->getWinner());
+        
+        // Get a battle that the player should lose and apply a buff that the player forces to win
+        $battle = $this->provideBuffBattleParticipants(new Buff([
+            "slot" => "test",
+            "rounds" => 99,
+            "goodguyInvulnurable" => true,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]), 0);
+        
+        $rounds = $battle->fightNRounds(99);
+        
+        $this->assertSame($battle->getPlayer()->getMaxHealth(), $battle->getPlayer()->getHealth());
+        $this->assertTrue($battle->isOver());
+        $this->assertSame($battle->getPlayer(), $battle->getWinner());
+    }
+    
+    public function testBufflistGoodguyAttackModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "goodguyAttackModifier" => 1.23,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "goodguyAttackModifier" => 0.126,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "goodguyAttackModifier" => 13.4,
+        ]));
+
+        $modifier = $player->getBuffs()->getGoodguyAttackModifier();
+        $this->assertEquals(0.15498, $modifier, '', 0.001);
+    }
+    
+    public function testBufflistGoodguyDefenseModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "goodguyDefenseModifier" => 1.293,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "goodguyDefenseModifier" => 5.6,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "goodguyDefenseModifier" => 0,
+        ]));
+
+        $modifier = $player->getBuffs()->getGoodguyDefenseModifier();
+        $this->assertEquals(7.2408, $modifier, '', 0.001);
+    }
+    
+    public function testBufflistGoodguyDamageModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "goodguyDamageModifier" => 10,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "goodguyDamageModifier" => 0.25,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "goodguyDamageModifier" => 3.5,
+        ]));
+
+        $modifier = $player->getBuffs()->getGoodguyDamageModifier();
+        $this->assertEquals(2.5, $modifier, '', 0.001);
+    }
+    
+    public function testBufflistBadguyAttackModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "badguyAttackModifier" => 1.23,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "badguyAttackModifier" => 0.126,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "badguyAttackModifier" => 13.4,
+        ]));
+
+        $modifier = $player->getBuffs()->getBadguyAttackModifier();
+        $this->assertEquals(0.15498, $modifier, '', 0.001);
+    }
+    
+    public function testBufflistBadguyDefenseModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "badguyDefenseModifier" => 1.293,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "badguyDefenseModifier" => 5.6,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "badguyDefenseModifier" => 0,
+        ]));
+
+        $modifier = $player->getBuffs()->getBadguyDefenseModifier();
+        $this->assertEquals(7.2408, $modifier, '', 0.001);
+    }
+    
+    public function testBufflistBadguyDamageModifier()
+    {
+        $em = $this->getEntityManager();
+        $player = $em->getRepository(Character::class)->find(1);
+        $game = $this->getMockGame($player);
+        
+        $player->addBuff(new Buff([
+            "slot" => "test1",
+            "rounds" => 1,
+            "badguyDamageModifier" => 10,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test2",
+            "rounds" => 1,
+            "badguyDamageModifier" => 0.25,
+            "activateAt" => Buff::ACTIVATE_ROUNDSTART,
+        ]));
+        $player->addBuff(new Buff([
+            "slot" => "test3",
+            "rounds" => 1,
+            "badguyDamageModifier" => 3.5,
+        ]));
+
+        $modifier = $player->getBuffs()->getBadguyDamageModifier();
+        $this->assertEquals(2.5, $modifier, '', 0.001);
+    }
 }

--- a/tests/datasets/battle.yml
+++ b/tests/datasets/battle.yml
@@ -20,6 +20,13 @@ characters:
         health: 10
         maxhealth: 10
         level: 1
+    -
+        id: 4
+        name: "Low Damage Char"
+        displayName: "Low Damage Char"
+        health: 500
+        maxhealth: 500
+        level: 0
 monsters:
     -
         id: 1

--- a/tests/datasets/battle.yml
+++ b/tests/datasets/battle.yml
@@ -27,6 +27,27 @@ characters:
         health: 500
         maxhealth: 500
         level: 0
+    -
+        id: 10
+        name: "Level 10 Character"
+        displayName: "Level 10 Character"
+        health: 100
+        maxhealth: 100
+        level: 10
+    -
+        id: 11
+        name: "Level 11 Character"
+        displayName: "Level 11 Character"
+        health: 110
+        maxhealth: 110
+        level: 11
+    -
+        id: 13
+        name: "Level 13 Character"
+        displayName: "Level 13 Character"
+        health: 130
+        maxhealth: 130
+        level: 13
 monsters:
     -
         id: 1
@@ -40,3 +61,15 @@ monsters:
         id: 3
         name: "Stone"
         level: 1
+    -
+        id: 10
+        name: "Level 10 Monster"
+        level: 10
+    -
+        id: 11
+        name: "Level 11 Monster"
+        level: 11
+    -
+        id: 13
+        name: "Level 13 Monster"
+        level: 13


### PR DESCRIPTION
This PR adds the buff functionality to the battle object. It supports all buff types supported by LotGD 0.9.7 and extends upon them by introducing a bunch of other variables to complete the buff set.

The buff fields have been renamed to describe their effect in more detail and to make it clear upon whom the buff acts. All buffs are added as events, meaning that player or monster death can happen after every applied buff event as well.

A list of supported buff fields can be taken from the buff model file were they are described in greater detail.
