### PR TITLE
Add API to extend annotation metadata directory

### DIFF
--- a/tests/AdditionalEntities/UserEntity.php
+++ b/tests/AdditionalEntities/UserEntity.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests\AdditionalEntities;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="Users")
+ */
+class UserEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    private $id;
+    /** @Column(type="string", length=50); */
+    private $name;
+    
+    public function getId(): int
+    {
+        return $this->id;
+    }
+    
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace LotGD\Core\Tests;
 
 use LotGD\Core\Bootstrap;
+use LotGD\Core\Tests\AdditionalEntities\UserEntity;
 
 class BootstrapTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,5 +13,28 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $g = Bootstrap::createGame();
         $this->assertNotNull($g->getEntityManager());
         $this->assertNotNull($g->getEventManager());
+    }
+    
+    public function testDoctrineReadsAnnotationsFromAdditionalMetaDataDirectory()
+    {
+        Bootstrap::registerAnnotationMetaDataDirectory(__DIR__ . "/AdditionalEntities");
+        
+        $g = Bootstrap::createGame();
+        
+        $user = new UserEntity();
+        $user->setName("Monthy");
+        
+        $g->getEntityManager()->persist($user);
+        $g->getEntityManager()->flush();
+        
+        $id = $user->getId();
+        $this->assertInternalType("int", $id);
+        
+        $g->getEntityManager()->clear();
+        $user = $g->getEntityManager()->getRepository(UserEntity::class)->find($id);
+        
+        $this->assertInternalType("int", $user->getId());
+        $this->assertInternalType("string", $user->getName());
+        $this->assertSame("Monthy", $user->getName());
     }
 }


### PR DESCRIPTION
This commit adds the possibility for externals to add additional
directories in order to extend the directories doctrine uses to read
metadata from.

Fixes #38.
