### PR TITLE
Making bin/daenerys more extensible

### DIFF
--- a/bin/daenerys
+++ b/bin/daenerys
@@ -1,5 +1,8 @@
 #!/usr/bin/env php
 <?php
+
+use LotGD\Core\Bootstrap;
+
 function includeIfExists($file) 
 {
     if (file_exists($file)) {
@@ -13,4 +16,8 @@ includeIfExists(getcwd() . '/vendor/autoload.php') ||
 includeIfExists(__DIR__ . '/../vendor/autoload.php') ||
 includeIfExists(__DIR__ . '/../autoload.php');
 
-LotGD\Core\Console\Main::main();
+$loader = function () {
+    return Bootstrap::createGame();
+};
+
+LotGD\Core\Console\Main::main($loader);

--- a/src/Console/Command/DatabaseInitCommand.php
+++ b/src/Console/Command/DatabaseInitCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LotGD\Core\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use LotGD\Core\Console\Main;
+
+class DatabaseInitCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName('database:init')
+             ->setDescription('Initiates database with default values.');
+    }
+    
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $g = Main::createGame();
+        
+        $g->getEntityManager()->flush();
+    }
+}

--- a/src/Console/Command/ModuleRegisterCommand.php
+++ b/src/Console/Command/ModuleRegisterCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use LotGD\Core\Bootstrap;
+use LotGD\Core\Console\Main;
 use LotGD\Core\Exceptions\ClassNotFoundException;
 use LotGD\Core\Exceptions\ModuleAlreadyExistsException;
 
@@ -24,7 +24,7 @@ class ModuleRegisterCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $g = Bootstrap::createGame();
+        $g = Main::createGame();
 
         $modules = $g->getComposerManager()->getModulePackages();
 

--- a/src/Console/Command/ModuleValidateCommand.php
+++ b/src/Console/Command/ModuleValidateCommand.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Console\Command;
 
-use LotGD\Core\Bootstrap;
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
+use LotGD\Core\Console\Main;
 
 class ModuleValidateCommand extends Command
 {
@@ -21,7 +21,7 @@ class ModuleValidateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $g = Bootstrap::createGame();
+        $g = Main::createGame();
 
         $results = $g->getModuleManager()->validate();
 

--- a/src/Console/Main.php
+++ b/src/Console/Main.php
@@ -3,11 +3,42 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Console;
 
-use LotGD\Core\Console\Command\ModuleValidateCommand;
-use LotGD\Core\Console\Command\ModuleRegisterCommand;
 use Symfony\Component\Console\Application;
 
+use LotGD\Core\Bootstrap;
+use LotGD\Core\Game;
+use LotGD\Core\Console\Command\{
+    DatabaseInitCommand,
+    ModuleValidateCommand,
+    ModuleRegisterCommand
+};
+
 class Main {
+    protected static $loader = null;
+    
+    /**
+     * Saves a closure used as bootstrap loader
+     * @param \Closure $loader
+     */
+    public static function setBootstrapLoader(\Closure $loader)
+    {
+        self::$loader = $loader;
+    }
+    
+    /**
+     * Creates the game using the previously stored bootstrap loader or
+     * uses the default one
+     * @return Game
+     */
+    public static function createGame(): Game
+    {
+        if (is_null(self::$loader)) {
+            return Bootstrap::createGame();
+        }
+        
+        return $loader();
+    }
+            
     public static function main()
     {
         $application = new Application();
@@ -17,6 +48,8 @@ class Main {
 
         $application->add(new ModuleValidateCommand());
         $application->add(new ModuleRegisterCommand());
+        $application->add(new DatabaseInitCommand());
+        
         $application->run();
     }
 }


### PR DESCRIPTION
In order to make bin/daenerys more extensible and usable from outside with
more configuration, the bootstrap of the game object has been moved to
bin/daenerys where it is a closure stored in LotGD\Core\Console\Main.
Commands now call Main::createGame() instead of Bootstrap::createGame().

Added the command database:init
