### PR TITLE
Add support for "module bootstrapping"

### DIFF
--- a/bin/daenerys
+++ b/bin/daenerys
@@ -3,21 +3,13 @@
 
 use LotGD\Core\Bootstrap;
 
-function includeIfExists($file) 
-{
-    if (file_exists($file)) {
-        return include $file;
-    }
-}
-
-// Dance to find the autoloader.
-// TOOD: change this to open up the Composer config and use $c['config']['vendor-dir'] instead of "vendor"
-includeIfExists(getcwd() . '/vendor/autoload.php') ||
-includeIfExists(__DIR__ . '/../vendor/autoload.php') ||
-includeIfExists(__DIR__ . '/../autoload.php');
+$daenerys = require __DIR__ . "/../bootstrap/console.php";
 
 $loader = function () {
+    putenv("LOTGD_CONFIG=./config/test.yml");
     return Bootstrap::createGame();
 };
 
-LotGD\Core\Console\Main::main($loader);
+$daenerys::setBootstrapLoader($loader);
+
+$daenerys->run();

--- a/bootstrap/console.php
+++ b/bootstrap/console.php
@@ -1,0 +1,19 @@
+<?php
+
+use LotGD\Core\Console\Main as DaenerysConsole;
+
+function includeIfExists($file) 
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
+
+// Dance to find the autoloader.
+// TOOD: change this to open up the Composer config and use $c['config']['vendor-dir'] instead of "vendor"
+includeIfExists(getcwd() . '/vendor/autoload.php') ||
+includeIfExists(__DIR__ . '/../vendor/autoload.php') ||
+includeIfExists(__DIR__ . '/../autoload.php');
+
+
+return new DaenerysConsole();

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,5 +1,5 @@
 database:
-    dsn: sqlite::memory:
+    dsn: "sqlite::memory:"
     name: daenerys
     user: root
     password:

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AnsiQuoteStrategy;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\ORM\Tools\SchemaTool;
+use Monolog\Logger;
 
 use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Exceptions\InvalidConfigurationException;
@@ -15,6 +16,18 @@ use LotGD\Core\Exceptions\InvalidConfigurationException;
 class Bootstrap
 {
     private static $annotationMetaDataDirectories = [];
+    private static $bootstrapCrate = null;
+    
+    public static function clear()
+    {
+        self::$annotationMetaDataDirectories = [];
+        self::$bootstrapCrate = null;
+    }
+    
+    public static function registerCrateBootstrap(BootstrapInterface $bootstrap)
+    {
+        self::$bootstrapCrate = $bootstrap;
+    }
 
     public static function registerAnnotationMetaDataDirectory(string $directory)
     {
@@ -32,26 +45,82 @@ class Bootstrap
      */
     public static function createGame(): Game
     {
+        $config = self::createConfiguration();
+        
+        // Depending on config
+        $logger = self::createLogger($config);
+        $entityManager = self::createEntityManager($config);
+        
+        // Create game
+        $game = new Game($config, $entityManager, $logger);
+        
+        // Bootstrap modules
+        self::bootstrapModules($game);
+
+        return $game;
+    }
+    
+    /**
+     * Creates a configuration object
+     * @return \LotGD\Core\Configuration
+     * @throws InvalidConfigurationException
+     */
+    protected static function createConfiguration(): Configuration
+    {
+        // Get the path of LOTGD_CONFIG from the environmental variables
         $configFilePath = getenv('LOTGD_CONFIG');
         if ($configFilePath === false || strlen($configFilePath) == 0 || is_file($configFilePath) === false) {
             throw new InvalidConfigurationException("Invalid or missing configuration file: '{$configFilePath}'.");
         }
-        $config = new Configuration($configFilePath);
-
-        $logger = new \Monolog\Logger('lotgd');
+        
+        return new Configuration($configFilePath);
+    }
+    
+    /**
+     * Creates a logger object
+     * @return Logger
+     */
+    protected static function createLogger(Configuration $config): Logger
+    {
+        $logger = new Logger('lotgd');
+        
         // Add lotgd as the prefix for the log filenames.
         $logger->pushHandler(new \Monolog\Handler\RotatingFileHandler($config->getLogPath() . DIRECTORY_SEPARATOR . 'lotgd', 14));
 
         $v = Game::getVersion();
         $logger->info("Bootstrap constructing game (Daenerys 🐲{$v}).");
-
+        
+        return $logger;
+    }
+    
+    /**
+     * Creates an entity manager and connects to the database
+     * @param \LotGD\Core\Configuration $config
+     */
+    protected static function createEntityManager(Configuration $config): EntityManager
+    {
+        // Doctrine
         $pdo = new \PDO($config->getDatabaseDSN(), $config->getDatabaseUser(), $config->getDatabasePassword());
 
+        $entityManager = self::_createEntityManager($pdo);
+        
+        return $entityManager;
+    }
+    
+    protected static function _createEntityManager(\PDO $pdo, array $paths = [])
+    {
         // Read db annotations from model files
-        $annotationMetaDataDirectories = array_merge(
-            [__DIR__ . '/Models'],
-            self::$annotationMetaDataDirectories
-        );
+        if (count($paths) === 0) {
+            $annotationMetaDataDirectories = array_merge(
+                [__DIR__ . '/Models'],
+                self::$annotationMetaDataDirectories,
+                $paths
+            );
+        }
+        else {
+            $annotationMetaDataDirectories = $paths;
+        }
+        
         $configuration = Setup::createAnnotationMetadataConfiguration($annotationMetaDataDirectories, true);
 
         // Set a quote
@@ -63,9 +132,41 @@ class Bootstrap
         $metaData = $entityManager->getMetadataFactory()->getAllMetadata();
         $schemaTool = new SchemaTool($entityManager);
         $schemaTool->updateSchema($metaData);
-
-        $eventManager = new EventManager($entityManager);
-
-        return new Game($config, $entityManager, $eventManager, $logger);
+        
+        return $entityManager;
+    }
+    
+    public static function bootstrapModules(Game $game)
+    {
+        $entityDirectories = array_merge(
+            [__DIR__ . '/Models'],
+            self::$annotationMetaDataDirectories
+        );
+        
+        // Bootstrap crate first
+        if (!is_null(self::$bootstrapCrate)) {
+            if (self::$bootstrapCrate->hasEntityPath()) {
+                $entityDirectories[] = self::$bootstrapCrate->getEntityPath();
+            }
+        }
+        
+        // Bootstrap modules        
+        foreach($game->getModuleManager()->getModules() as $module) {
+            // ToDo: Fetch module
+        }
+        
+        // Update database annotations
+        $em = $game->getEntityManager();
+        $em->flush();
+        $em->close();
+        
+        // Get Connection
+        $pdo = $em->getConnection()->getWrappedConnection();
+        
+        // Create NEW entity Manager
+        $em = self::_createEntityManager($pdo, $entityDirectories);
+        
+        // Set NEW entity Manager
+        $game->setEntityManager($em);
     }
 }

--- a/src/BootstrapInterface.php
+++ b/src/BootstrapInterface.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+interface BootstrapInterface
+{
+    public function hasEntityPath(): bool;
+    public function getEntityPath(): string;
+}

--- a/src/Console/Main.php
+++ b/src/Console/Main.php
@@ -36,11 +36,16 @@ class Main {
         if (is_null(self::$loader)) {
             return Bootstrap::createGame();
         }
+        
+        $closure = self::$loader;
 
-        return $loader();
+        return $closure();
     }
 
-    public static function main()
+    /**
+     * Runs the console function
+     */
+    public function run()
     {
         $application = new Application();
 

--- a/src/Game.php
+++ b/src/Game.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace LotGD\Core;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
 
 use LotGD\Core\Models\Character;
 
@@ -19,12 +20,10 @@ class Game
     public function __construct(
         Configuration $configuration,
         EntityManagerInterface $entityManager,
-        EventManager $eventManager,
         \Monolog\Logger $logger)
     {
         $this->configuration = $configuration;
         $this->entityManager = $entityManager;
-        $this->eventManager = $eventManager;
         $this->logger = $logger;
     }
 
@@ -78,6 +77,15 @@ class Game
     {
         return $this->entityManager;
     }
+    
+    /**
+     * Replaces the game's entity manager with a new one.
+     * @param EntityManagerInterface $em
+     */
+    public function setEntityManager(EntityManagerInterface $em)
+    {
+        $this->entityManager = $em;
+    }
 
     /**
      * Returns the game's event manager.
@@ -85,6 +93,10 @@ class Game
      */
     public function getEventManager(): EventManager
     {
+        if ($this->eventManager === null) {
+            $this->eventManager = new EventManager($this->getEntityManager());
+        }
+        
         return $this->eventManager;
     }
 

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -6,6 +6,7 @@ namespace LotGD\Core;
 use Composer\Package\PackageInterface;
 use Doctrine\ORM\EntityManagerInterface;
 
+use LotGD\Core\BootstrapInterface;
 use LotGD\Core\Exceptions\KeyNotFoundException;
 use LotGD\Core\Exceptions\ModuleAlreadyExistsException;
 use LotGD\Core\Exceptions\ModuleDoesNotExistException;

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 namespace LotGD\Core\Tests;
 
 use LotGD\Core\Bootstrap;
+use LotGD\Core\BootstrapInterface;
 use LotGD\Core\Tests\AdditionalEntities\UserEntity;
+
+class BootstrapCrate implements BootstrapInterface {
+    public function hasEntityPath(): bool { return true; }
+    public function getEntityPath(): string { return __DIR__ . "/AdditionalEntities"; }
+}
 
 class BootstrapTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,6 +24,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
 
     public function testDoctrineReadsAnnotationsFromAdditionalMetaDataDirectory()
     {
+        Bootstrap::clear();
         Bootstrap::registerAnnotationMetaDataDirectory(__DIR__ . "/AdditionalEntities");
 
         $g = Bootstrap::createGame();
@@ -33,6 +40,45 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
 
         $g->getEntityManager()->clear();
         $user = $g->getEntityManager()->getRepository(UserEntity::class)->find($id);
+
+        $this->assertInternalType("int", $user->getId());
+        $this->assertInternalType("string", $user->getName());
+        $this->assertSame("Monthy", $user->getName());
+    }
+    
+    public function testUserEntityDoesThrowDBALException() {
+        $this->expectException(\Doctrine\DBAL\DBALException::class);
+                
+        Bootstrap::clear();
+        
+        $game = Bootstrap::createGame();
+        
+        $user = new UserEntity();
+        $user->setName("Monthy");
+        
+        $game->getEntityManager()->persist($user);
+        $game->getEntityManager()->flush();
+    }
+    
+    public function testBootstrappedCrateDoesExtendDoctrine() {
+        Bootstrap::clear();
+        Bootstrap::registerCrateBootstrap(new BootstrapCrate());
+        
+        $game = Bootstrap::createGame();
+        
+        Bootstrap::bootstrapModules($game);
+        
+        $user = new UserEntity();
+        $user->setName("Monthy");
+
+        $game->getEntityManager()->persist($user);
+        $game->getEntityManager()->flush();
+
+        $id = $user->getId();
+        $this->assertInternalType("int", $id);
+
+        $game->getEntityManager()->clear();
+        $user = $game->getEntityManager()->getRepository(UserEntity::class)->find($id);
 
         $this->assertInternalType("int", $user->getId());
         $this->assertInternalType("string", $user->getName());


### PR DESCRIPTION
Adds support for "module bootstrapping" - modules (and the crate) can implement BootstrapInterface. The crate should add it's own Bootstrap class using a custom bootstrap loader calling `Bootstrap::registerCrateBootstrap`. `registerAnnotationMetaDataDirectory` is deprecated.

Makes it easier to copy binary file while reducing amount of code duplicates.
