### PR TITLE
Add support for %cwd% variable in pdo dsn.

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -60,7 +60,8 @@ class Bootstrap
         $composer = $this->createComposerManager($cwd);
         $this->libraryConfigurationManager = $this->createLibraryConfigurationManager($composer, $cwd);
 
-        $pdo = $this->connectToDatabase($config);
+        list($dsn, $user, $password) = $config->getDatabaseConnectionDetails($cwd);
+        $pdo = $this->connectToDatabase($dsn, $user, $password);
         $entityManager = $this->createEntityManager($pdo);
 
         $this->game = new Game($config, $this->logger, $entityManager, $cwd);
@@ -86,15 +87,9 @@ class Bootstrap
      * @param \LotGD\Core\Configuration $config
      * @return \PDO
      */
-    protected function connectToDatabase(Configuration $config, string $cwd): \PDO
+    protected function connectToDatabase(string $dsn, string $user, string $password): \PDO
     {
-        $dsn = str_replace("%cwd%", $cwd, $config->getDatabaseDSN());
-        
-        return new \PDO(
-            $dsn, 
-            $config->getDatabaseUser(), 
-            $config->getDatabasePassword()
-        );
+        return new \PDO($dsn, $user, $password);
     }
 
     /**

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -86,9 +86,15 @@ class Bootstrap
      * @param \LotGD\Core\Configuration $config
      * @return \PDO
      */
-    protected function connectToDatabase(Configuration $config): \PDO
+    protected function connectToDatabase(Configuration $config, string $cwd): \PDO
     {
-        return new \PDO($config->getDatabaseDSN(), $config->getDatabaseUser(), $config->getDatabasePassword());
+        $dsn = str_replace("%cwd%", $cwd, $config->getDatabaseDSN());
+        
+        return new \PDO(
+            $dsn, 
+            $config->getDatabaseUser(), 
+            $config->getDatabasePassword()
+        );
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -53,23 +53,15 @@ class Configuration
         $name = $rawConfig['database']['name'] ?? '';
 
         if ($dsn === false || strlen($dsn) == 0) {
-            $m = "Invalid or missing data source name: {$dsn}";
-            $logger->critical($m);
-            throw new InvalidConfigurationException($m);
+            throw new InvalidConfigurationException("Invalid or missing data source name: {$dsn}");
         }
         if ($user === false || strlen($user) == 0) {
-            $m = "Invalid or missing database user: {$user}";
-            $logger->critical($m);
             throw new InvalidConfigurationException("Invalid or missing database user: {$user}");
         }
         if ($passwd === false) {
-            $m = "Invalid or missing database password: {$passwd}";
-            $logger->critical($m);
             throw new InvalidConfigurationException("Invalid or missing database password: {$passwd}");
         }
         if ($name === false) {
-            $m = "Invalid or missing database name: {$name}";
-            $logger->critical($m);
             throw new InvalidConfigurationException("Invalid or missing database name: {$name}");
         }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -91,6 +91,11 @@ class Configuration
         $this->gameDaysPerDay = $gameDaysPerDay;
     }
     
+    /**
+     * Retrieves raw config via Yaml::parse from a given file.
+     * @param string $configFilePath File used to parse with Yaml
+     * @return array Raw config
+     */
     protected function retrieveRawConfig(string $configFilePath): array
     {
         return Yaml::parse(file_get_contents($configFilePath));

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -33,7 +33,7 @@ class Configuration
     public function __construct(string $configFilePath)
     {
         try {
-            $rawConfig = Yaml::parse(file_get_contents($configFilePath));
+            $rawConfig = $this->retrieveRawConfig($configFilePath);
         } catch (ParseException $e) {
             $m = $e->getMessage();
             throw new InvalidConfigurationException("Unable to parse configuration file at {$configFilePath}: {$m}");
@@ -97,6 +97,30 @@ class Configuration
         $this->gameEpoch = (new DateTime())->setTimestamp($gameEpoch);
         $this->gameOffsetSeconds = $gameOffsetSeconds;
         $this->gameDaysPerDay = $gameDaysPerDay;
+    }
+    
+    protected function retrieveRawConfig(string $configFilePath): array
+    {
+        return Yaml::parse(file_get_contents($configFilePath));
+    }
+    
+    /**
+     * Returns database connection details needed for pdo to establish a connection.
+     * 
+     * This function takes optionally replaces the string %cwd% in the database dsn and
+     * replaces it with the first parameter. This is important to normalize the database location
+     * across different working directories. Alternatively, SQLite databse names can also directly
+     * be given as an absolute path instead of a relative one.
+     * @param string $cwd Current working directory
+     * @return array A list containing the following details: dsn, user, password.
+     */
+    public function getDatabaseConnectionDetails(string $cwd = ""): array
+    {
+        return [
+            str_replace("%cwd%", $cwd, $this->getDatabaseDSN()),
+            $this->getDatabaseUser(),
+            $this->getDatabasePassword(),
+        ];
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -109,7 +109,7 @@ class Configuration
     public function getDatabaseConnectionDetails(string $cwd = ""): array
     {
         return [
-            str_replace("%cwd%", $cwd, $this->getDatabaseDSN()),
+            str_replace("%cwd%", $cwd . DIRECTORY_SEPARATOR, $this->getDatabaseDSN()),
             $this->getDatabaseUser(),
             $this->getDatabasePassword(),
         ];

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -44,4 +44,25 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(strpos($s, 'some_password'));
     }
+    
+    private function getPseudoConfiguration(array $config)
+    {
+        $configuration = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->setMethods(["retrieveRawConfig"])
+            ->getMock();
+        
+        $configuration->__construct("dummy");
+        return $configuration;
+    }
+    
+    public function testCWDParsingForSQLiteDatabaseDSN()
+    {
+        $configuration = $this->getPseudoConfiguration([
+            "dsn" => "sqlite:%cwd%db.db3",
+            "user" => "daenerys",
+            "password" => "",
+            "name" => "daenerys"
+        ]);
+    }
 }


### PR DESCRIPTION
The string %cwd% gets replaced in a pdo dsn with the cwd used to create the game. This is important since daenerys would access a different sqlite database file than web/app.php
