### PR TITLE
Refactor ModelTestCase so I can use it outside of the Core.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,7 @@
 <phpunit bootstrap="bootstrap/bootstrap.php">
+    <php>
+        <env name="LOTGD_TESTS_CONFIG_PATH" value="./config/lotgd.yml"/>
+    </php>
     <testsuites>
         <testsuite name="All">
             <directory>tests</directory>

--- a/src/LibraryConfiguration.php
+++ b/src/LibraryConfiguration.php
@@ -38,12 +38,17 @@ class LibraryConfiguration
         $this->composerManager = $composerManager;
         $this->package = $package;
 
-        // Only lotgd-modules are installed in the vendor directory
         $path = '';
-        if ($package->getType() === "lotgd-module") {
+        $basePackage = $composerManager->getComposer()->getPackage();
+        if ($basePackage && $basePackage->getName() === $package->getName()) {
+            // Whatever the base package is in this repo is at $cwd.
+            $path = $cwd;
+        } else if ($package->getType() === "lotgd-module") {
+            // lotgd-modules are installed in the vendor directory.
             $installationManager = $composerManager->getComposer()->getInstallationManager();
             $path = $installationManager->getInstallPath($package);
         } else {
+            // Not sure what it is honestly, just use $cwd.
             $path = $cwd;
         }
 

--- a/tests/CoreModelTestCase.php
+++ b/tests/CoreModelTestCase.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests;
+
+class CoreModelTestCase extends ModelTestCase
+{
+    /**
+     * Returns a .yml dataset under this name
+     * @return \PHPUnit_Extensions_Database_DataSet_YamlDataSet
+     */
+    protected function getDataSet(): \PHPUnit_Extensions_Database_DataSet_YamlDataSet
+    {
+        return new \PHPUnit_Extensions_Database_DataSet_YamlDataSet(implode(DIRECTORY_SEPARATOR, [__DIR__, 'datasets', $this->dataset . '.yml']));
+    }
+}

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -10,7 +10,7 @@ use LotGD\Core\Exceptions\WrongTypeException;
 use LotGD\Core\Exceptions\ClassNotFoundException;
 use LotGD\Core\Exceptions\SubscriptionNotFoundException;
 use LotGD\Core\Models\EventSubscription;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 use LotGD\Core\Tests\FakeModule\Module as FakeModule;
 
 class EventManagerTestInvalidSubscriber
@@ -23,7 +23,7 @@ class EventManagerTestSubscriber implements EventHandler
     public static function handleEvent(Game $g, string $event, array &$context) {}
 }
 
-class EventManagerTest extends ModelTestCase
+class EventManagerTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "eventManager";

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -21,7 +21,7 @@ use LotGD\Core\Exceptions\ {
     CharacterNotFoundException,
     InvalidConfigurationException
 };
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 class DefaultSceneProvider implements EventHandler
 {
@@ -48,7 +48,7 @@ class DefaultSceneProvider implements EventHandler
     }
 }
 
-class GameTest extends ModelTestCase
+class GameTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "game";
@@ -62,7 +62,7 @@ class GameTest extends ModelTestCase
         $logger  = new Logger('test');
         $logger->pushHandler(new NullHandler());
 
-        $this->g = new Game(new Configuration(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'config', 'lotgd.yml'])), $logger, $this->getEntityManager(), implode(DIRECTORY_SEPARATOR, [__DIR__, '..']));
+        $this->g = new Game(new Configuration(getenv('LOTGD_TESTS_CONFIG_PATH')), $logger, $this->getEntityManager(), implode(DIRECTORY_SEPARATOR, [__DIR__, '..']));
     }
 
     public function testGetCharacterException()

--- a/tests/Models/CharacterModelTest.php
+++ b/tests/Models/CharacterModelTest.php
@@ -5,13 +5,13 @@ namespace LotGD\Core\Tests\Models;
 
 use LotGD\Core\Models\Character;
 use LotGD\Core\Models\CharacterProperty;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 use LotGD\Core\Models\Repositories\CharacterRepository;
 
 /**
  * Tests the management of Characters
  */
-class CharacterModelTest extends ModelTestCase
+class CharacterModelTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "character";

--- a/tests/Models/CharacterViewpointTest.php
+++ b/tests/Models/CharacterViewpointTest.php
@@ -9,7 +9,7 @@ use LotGD\Core\Attachment;
 use LotGD\Core\Models\Character;
 use LotGD\Core\Models\CharacterViewpoint;
 use LotGD\Core\Models\Scene;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 class SampleAttachment extends Attachment
 {
@@ -30,7 +30,7 @@ class SampleAttachment extends Attachment
 /**
  * Tests the management of CharacterViewpoints
  */
-class CharacterViewpointTest extends ModelTestCase
+class CharacterViewpointTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "characterViewpoints";

--- a/tests/Models/GameConfigurationTest.php
+++ b/tests/Models/GameConfigurationTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 namespace LotGD\Core\Tests\Models;
 
 use LotGD\Core\Models\GameConfiguration;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 /**
  * Tests the management of CharacterScenes
  */
-class GameConfigurationTest extends ModelTestCase
+class GameConfigurationTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "gameConfiguration";

--- a/tests/Models/MessageModelTest.php
+++ b/tests/Models/MessageModelTest.php
@@ -7,12 +7,12 @@ use LotGD\Core\Models\Character;
 use LotGD\Core\Models\MessageThread;
 use LotGD\Core\Models\Message;
 use LotGD\Core\Models\Repositories\CharacterRepository;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 /**
  * Tests the management of Characters
  */
-class MessageModelTest extends ModelTestCase
+class MessageModelTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "messages";

--- a/tests/Models/ModuleTest.php
+++ b/tests/Models/ModuleTest.php
@@ -5,12 +5,12 @@ namespace LotGD\Core\Tests\Models;
 
 use LotGD\Core\Models\Module;
 use LotGD\Core\Models\ModuleProperty;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 /**
  * Tests for module management.
  */
-class ModuleTest extends ModelTestCase
+class ModuleTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "module";

--- a/tests/Models/MotdModelTest.php
+++ b/tests/Models/MotdModelTest.php
@@ -5,12 +5,12 @@ namespace LotGD\Core\Tests\Models;
 
 use LotGD\Core\Models\Character;
 use LotGD\Core\Models\MotD;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 /**
  * Tests the management of Characters
  */
-class MotDModelTest extends ModelTestCase
+class MotDModelTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "motd";

--- a/tests/Models/SceneModelTest.php
+++ b/tests/Models/SceneModelTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 namespace LotGD\Core\Tests\Models;
 
 use LotGD\Core\Models\Scene;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 
 /**
  * Tests for creating scenes and moving them around.
  */
-class SceneModelTest extends ModelTestCase
+class SceneModelTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "scene";

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -16,10 +16,10 @@ use LotGD\Core\ModuleManager;
 use LotGD\Core\Module;
 use LotGD\Core\Exceptions\ModuleAlreadyExistsException;
 use LotGD\Core\Exceptions\ModuleDoesNotExistException;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 use LotGD\Core\Tests\FakeModule\Module as FakeModule;
 
-class ModuleManagerTest extends ModelTestCase
+class ModuleManagerTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "module";

--- a/tests/OneToManyCollectionTest.php
+++ b/tests/OneToManyCollectionTest.php
@@ -7,13 +7,13 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 use LotGD\Core\Models\GameConfigurationElement;
 use LotGD\Core\Tools\OneToManyCollection;
-use LotGD\Core\Tests\ModelTestCase;
+use LotGD\Core\Tests\CoreModelTestCase;
 use LotGD\Core\Exceptions\WrongTypeException;
 
 /**
  * Tests for creating scenes and moving them around.
  */
-class OneToManyCollectionTest extends ModelTestCase
+class OneToManyCollectionTest extends CoreModelTestCase
 {
     /** @var string default data set */
     protected $dataset = "gameConfiguration";


### PR DESCRIPTION
Find the configuration file for the tests from an environment variable. This way I can reuse ModelTestCase inside the module repos, but not have to have the same directory structure, namely that I think having a `config/` directory would be very misleading for a module repo, so Ill put the config file within the `tests/` directory.
