### PR TITLE
Adds fixes and tests for cascade=persist, remove for scene entities.

### DIFF
--- a/src/Models/Scene.php
+++ b/src/Models/Scene.php
@@ -35,12 +35,12 @@ class Scene implements CreateableInterface, SceneConnectable
     private $connectionGroups = null;
 
     /**
-     * @OneToMany(targetEntity="SceneConnection", mappedBy="outgoingScene", cascade={"persist"})
+     * @OneToMany(targetEntity="SceneConnection", mappedBy="outgoingScene", cascade={"persist", "remove"})
      */
     private $outgoingConnections = null;
 
     /**
-     * @OneToMany(targetEntity="SceneConnection", mappedBy="incomingScene", cascade={"persist"})
+     * @OneToMany(targetEntity="SceneConnection", mappedBy="incomingScene", cascade={"persist", "remove"})
      */
     private $incomingConnections = null;
 
@@ -50,7 +50,6 @@ class Scene implements CreateableInterface, SceneConnectable
     private static $fillable = [
         "title",
         "description",
-        "parents",
         "template"
     ];
 

--- a/src/Models/SceneConnection.php
+++ b/src/Models/SceneConnection.php
@@ -15,15 +15,15 @@ class SceneConnection
 {
     /**
      * @Id
-     * @ManyToOne(targetEntity="Scene", inversedBy="outgoingConnections", cascade={"persist"})
-     * @JoinColumn(name="outgoing_scene_id", referencedColumnName="id")
+     * @ManyToOne(targetEntity="Scene")
+     * @JoinColumn(name="outgoingScene", referencedColumnName="id")
      */
     private $outgoingScene;
 
     /**
      * @Id
-     * @ManyToOne(targetEntity="Scene", inversedBy="incomingConnections", cascade={"persist"})
-     * @JoinColumn(name="incoming_scene_id", referencedColumnName="id")
+     * @ManyToOne(targetEntity="Scene")
+     * @JoinColumn(name="incomingScene", referencedColumnName="id")
      */
     private $incomingScene;
 

--- a/src/Models/SceneConnectionGroup.php
+++ b/src/Models/SceneConnectionGroup.php
@@ -19,7 +19,7 @@ class SceneConnectionGroup implements SceneConnectable
     /**
      * @Id
      * @ManyToOne(targetEntity="Scene", inversedBy="outgoingConnections", cascade={"persist"})
-     * @JoinColumn(name="scene_id", referencedColumnName="id")
+     * @JoinColumn(name="scene", referencedColumnName="id")
      */
     private $scene;
 

--- a/tests/ModelTestCase.php
+++ b/tests/ModelTestCase.php
@@ -82,4 +82,10 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
         // Clear out the cache so tests don't get confused.
         $this->getEntityManager()->clear();
     }
+
+    protected function flushAndClear()
+    {
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+    }
 }

--- a/tests/datasets/game.yml
+++ b/tests/datasets/game.yml
@@ -53,38 +53,38 @@ scenes:
         template: "lotgd/tests/none"
 scene_connection_groups:
     -
-        scene_id: 4
+        scene: 4
         name: "lotgd/tests/none/child1"
         title: "Child 1"
     -
-        scene_id: 4
+        scene: 4
         name: "lotgd/tests/none/child2"
         title: "Child 2"
 scene_connections:
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 2
+        outgoingScene: 1
+        incomingScene: 2
         directionality: 0
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 3
+        outgoingScene: 1
+        incomingScene: 3
         directionality: 0
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 4
+        outgoingScene: 1
+        incomingScene: 4
         directionality: 0
     -
-        outgoing_scene_id: 4
-        incoming_scene_id: 5
+        outgoingScene: 4
+        incomingScene: 5
         outgoingConnectionGroupName: "lotgd/tests/none/child1"
         directionality: 0
     -
-        outgoing_scene_id: 4
-        incoming_scene_id: 6
+        outgoingScene: 4
+        incomingScene: 6
         outgoingConnectionGroupName: "lotgd/tests/none/child2"
         directionality: 0
     -
-        outgoing_scene_id: 5
-        incoming_scene_id: 6
+        outgoingScene: 5
+        incomingScene: 6
         directionality: 1
 

--- a/tests/datasets/scene.yml
+++ b/tests/datasets/scene.yml
@@ -26,28 +26,28 @@ scenes:
         template: "lotgd/tests/orphan"
 scene_connection_groups:
     -
-        scene_id: 1
+        scene: 1
         name: "lotgd/tests/village/outside"
         title: "Outside"
     -
-        scene_id: 1
+        scene: 1
         name: "lotgd/tests/village/market"
         title: "Market"
     -
-        scene_id: 1
+        scene: 1
         name: "lotgd/tests/village/empty"
         title: "Empty"
     -
-        scene_id: 2
+        scene: 2
         name: "lotgd/tests/forest/category"
         title: "Empty"
 scene_connections:
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 2
+        outgoingScene: 1
+        incomingScene: 2
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 3
+        outgoingScene: 1
+        incomingScene: 3
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 4
+        outgoingScene: 1
+        incomingScene: 4

--- a/tests/datasets/viewpoints.yml
+++ b/tests/datasets/viewpoints.yml
@@ -34,8 +34,8 @@ scenes:
         template: "lotgd/tests/weaponry"
 scene_connections:
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 2
+        outgoingScene: 1
+        incomingScene: 2
     -
-        outgoing_scene_id: 1
-        incoming_scene_id: 3
+        outgoingScene: 1
+        incomingScene: 3


### PR DESCRIPTION
It still looks like doctrine doesn't "know" about the column names in a cascade=remove relationship and assumes the property name to be also the column name - which is usually not true (by default, it's propertyname_id).

This update changes the column name so that doctrine's assumptions are correct again and adds tests so any changes which invalidates this relationship can be gecocnized easily.