### PR TITLE
Adds a GameBuilder to allow better dependency injection

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -64,7 +64,12 @@ class Bootstrap
         $pdo = $this->connectToDatabase($dsn, $user, $password);
         $entityManager = $this->createEntityManager($pdo);
 
-        $this->game = new Game($config, $this->logger, $entityManager, $cwd);
+        $this->game = (new GameBuilder())
+            ->withConfiguration($config)
+            ->withLogger($this->logger)
+            ->withEntityManager($entityManager)
+            ->withCwd($cwd)
+            ->create();
 
         return $this->game;
     }

--- a/src/Exceptions/BuilderException.php
+++ b/src/Exceptions/BuilderException.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Exceptions;
+
+/**
+ * Exception if a builder is missing an argument
+ */
+class BuilderException extends CoreException
+{
+    
+}

--- a/src/Game.php
+++ b/src/Game.php
@@ -85,10 +85,16 @@ class Game
      */
     public function getModuleManager(): ModuleManager
     {
-        if ($this->moduleManager === null) {
-            $this->moduleManager = new ModuleManager($this);
-        }
         return $this->moduleManager;
+    }
+
+    /**
+     * Sets the game's module manager.
+     * @param ModuleManager $moduleManager
+     */
+    public function setModuleManager(ModuleManager $moduleManager): void
+    {
+        $this->moduleManager = $moduleManager;
     }
 
     /**
@@ -97,10 +103,16 @@ class Game
      */
     public function getComposerManager(): ComposerManager
     {
-        if ($this->composerManager === null) {
-            $this->composerManager = new ComposerManager($this->cwd);
-        }
         return $this->composerManager;
+    }
+
+    /**
+     * Sets the game's composer manager.
+     * @param ComposerManager $composerManager
+     */
+    public function setComposerManager(ComposerManager $composerManager): void
+    {
+        $this->composerManager = $composerManager;
     }
 
     /**
@@ -118,10 +130,16 @@ class Game
      */
     public function getEventManager(): EventManager
     {
-        if ($this->eventManager === null) {
-            $this->eventManager = new EventManager($this);
-        }
         return $this->eventManager;
+    }
+
+    /**
+     * Sets the game's event manager.
+     * @param EventManager $eventManager
+     */
+    public function setEventManager(EventManager $eventManager): void
+    {
+        $this->eventManager = $eventManager;
     }
 
     /**
@@ -130,10 +148,16 @@ class Game
      */
     public function getDiceBag(): DiceBag
     {
-        if ($this->diceBag === null) {
-            $this->diceBag = new DiceBag();
-        }
         return $this->diceBag;
+    }
+
+    /**
+     * Sets the game's dice bag.
+     * @param DiceBag $diceBag
+     */
+    public function setDiceBag(DiceBag $diceBag): void
+    {
+        $this->diceBag = $diceBag;
     }
 
     /**

--- a/src/GameBuilder.php
+++ b/src/GameBuilder.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+
+use Doctrine\ORM\EntityManagerInterface;
+use Monolog\Logger;
+
+use LotGD\Core\Exceptions\BuilderException;
+
+/**
+ * The GameBuilder class is used to build a Game object with all dependencies that are needed.
+ *
+ * You must provide $cwd, $configuration, $entityManager and a logger instance using the with* methods.
+ * You can provide additional class *names* for additional dependency injections using the use* methods.
+ * @package LotGD\Core
+ */
+class GameBuilder
+{
+    private $cwd;
+    private $configuration;
+    private $entityManager;
+    private $logger;
+
+    private $moduleManagerClass;
+    private $composerManagerClass;
+    private $eventManagerClass;
+    private $diceBagClass;
+
+    /**
+     * Creates the game instance with the prepared parameters.
+     * @return Game
+     * @throws BuilderException if at least one of cwd, configuration, entityManager or logger as not been set.
+     */
+    public function create(): Game
+    {
+        if (isset($this->cwd, $this->configuration, $this->entityManager, $this->logger) === false) {
+            throw new BuilderException(
+                "For creating a game, you must set at least: cwd, configuration, entityManager and logger."
+            );
+        }
+
+        // construct the game
+        $game = new Game(
+            $this->configuration,
+            $this->logger,
+            $this->entityManager,
+            $this->cwd
+        );
+
+        // add additional managers to it
+        $moduleManager = $this->moduleManagerClass ?? ModuleManager::class;
+        $game->setModuleManager(new $moduleManager($game));
+
+        $composerManager = $this->composerManagerClass ?? ComposerManager::class;
+        $game->setComposerManager(new $composerManager($this->cwd));
+
+        $eventManager = $this->eventManagerClass ?? EventManager::class;
+        $game->setEventManager(new $eventManager($game));
+
+        $diceBag = $this->diceBagClass ?? DiceBag::class;
+        $game->setDiceBag(new $diceBag());
+
+
+        return $game;
+    }
+
+    /**
+     * Adds current working directory argument
+     * @param string $cwd
+     * @return self
+     */
+    public function withCwd(string $cwd): self
+    {
+        $this->cwd = $cwd;
+        return $this;
+    }
+
+    /**
+     * Configuration
+     * @param Configuration $conf
+     * @return self
+     */
+    public function withConfiguration(Configuration $conf): self
+    {
+        $this->configuration = $conf;
+        return $this;
+    }
+
+    /**
+     * Sets the logger for the game instance.
+     * @param EntityManagerInterface $em
+     * @return self
+     */
+    public function withEntityManager(EntityManagerInterface $em): self
+    {
+        $this->entityManager = $em;
+        return $this;
+    }
+
+    /**
+     * Sets the logger for the game instance.
+     * @param Logger $logger
+     * @return self
+     */
+    public function withLogger(Logger $logger): self
+    {
+        $this->logger = $logger;
+        return $this;
+    }
+
+    /**
+     * Sets the fqcn for the module manager to be used.
+     * @param string $moduleManagerFqcn
+     * @return self
+     */
+    public function useModuleManager(string $moduleManagerFqcn): self
+    {
+        $this->moduleManagerClass = $moduleManagerFqcn;
+        return $this;
+    }
+
+    /**
+     * Sets the fqcn for the composer manager to be used.
+     * @param string $composerManagerFqcn
+     * @return self
+     */
+    public function useComposerManager(string $composerManagerFqcn): self
+    {
+        $this->composerManagerClass = $composerManagerFqcn;
+        return $this;
+    }
+
+    /**
+     * Sets the fqcn for the event manager to be used.
+     * @param string $eventManagerFqcn
+     * @return GameBuilder
+     */
+    public function useEventManager(string $eventManagerFqcn): self
+    {
+        $this->eventManagerClass = $eventManagerFqcn;
+        return $this;
+    }
+
+    /**
+     * Sets the fqcn for the dice bag to be used.
+     * @param string $diceBagFqcn
+     * @return GameBuilder
+     */
+    public function useDiceBag(string $diceBagFqcn): self
+    {
+        $this->diceBagClass = $diceBagFqcn;
+        return $this;
+    }
+}

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -9,7 +9,7 @@ use Monolog\Logger;
 use Monolog\Handler\NullHandler;
 
 use LotGD\Core\{
-    Action, ActionGroup, Bootstrap, Configuration, ComposerManager, DiceBag, EventHandler, EventManager, Events\NewViewpointData, Game, TimeKeeper, ModuleManager
+    Action, ActionGroup, Bootstrap, Configuration, ComposerManager, DiceBag, EventHandler, EventManager, Events\NewViewpointData, Game, GameBuilder, TimeKeeper, ModuleManager
 };
 use LotGD\Core\Models\{
     Character, Viewpoint, Scene
@@ -85,7 +85,12 @@ class GameTest extends CoreModelTestCase
         $logger  = new Logger('test');
         $logger->pushHandler(new NullHandler());
 
-        $this->g = new Game(new Configuration(getenv('LOTGD_TESTS_CONFIG_PATH')), $logger, $this->getEntityManager(), implode(DIRECTORY_SEPARATOR, [__DIR__, '..']));
+        $this->g = (new GameBuilder())
+            ->withConfiguration(new Configuration(getenv('LOTGD_TESTS_CONFIG_PATH')))
+            ->withLogger($logger)
+            ->withEntityManager($this->getEntityManager())
+            ->withCwd(implode(DIRECTORY_SEPARATOR, [__DIR__, '..']))
+            ->create();
     }
 
     public function testBasicInjection()


### PR DESCRIPTION
GameBuilder implements a variation of the so called Builder pattern to keep backwards compability as high as possible.

It can be used, for example, to exchange the EventManger so that suscribing/unsuscribing test events is not needed anymore. Or it can be used to add a non-random "DiceBag" to make testing of random events easier by replacing it with a mock that only returns a known result.