### PR TITLE
Adds the foundation for viewpoint to be able to modify there descript…

### DIFF
--- a/src/Models/BasicEnemy.php
+++ b/src/Models/BasicEnemy.php
@@ -11,13 +11,13 @@ use Doctrine\ORM\Mapping\MappedSuperclass;
 abstract class BasicEnemy implements FighterInterface
 {
     /** @Id @Column(type="integer") @GeneratedValue */
-    private $id;
+    protected $id;
     /** @Column(type="string", length=50); */
-    private $name;
+    protected $name;
     /** @Column(type="integer"); */
-    private $level;
+    protected $level;
     /** @var int */
-    private $health;
+    protected $health;
     
     /**
      * Returns the enemy's id

--- a/src/Models/Viewpoint.php
+++ b/src/Models/Viewpoint.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
 use LotGD\Core\Action;
+use LotGD\Core\ActionGroup;
+use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\SceneBasics;
 use LotGD\Core\Tools\SceneDescription;
@@ -177,11 +179,38 @@ class Viewpoint implements CreateableInterface
     }
 
     /**
+     * Adds a new action group to a viewpoint
+     * @param ActionGroup $group The new group to add.
+     * @param null|string $after, optional group id that comes before.
+     * @throws ArgumentException
+     */
+    public function addActionGroup(ActionGroup $group, ?string $after = null): void
+    {
+        $groupid = $group->getId();
+        if ($this->findActionGroupById($groupid) == true) {
+            throw new ArgumentException("Group {$group} is already contained in this viewpoint.");
+        }
+
+        if ($after === null) {
+            $this->actionGroups[] = $group;
+        } else {
+            $groups = [];
+            foreach ($this->actionGroups as $g) {
+                if ($g->getId() == $after) {
+                    $groups[] = $group;
+                }
+                $groups[] = $g;
+            }
+            $this->actionGroups = $groups;
+        }
+    }
+
+    /**
      * Finds an action group by id.
      * @param $actionGroupId
      * @return ActionGroup|null
      */
-    public function findActionGroupById(string $actionGroupId)
+    public function findActionGroupById(string $actionGroupId): ?ActionGroup
     {
         $groups = $this->getActionGroups();
         foreach ($groups as $g) {
@@ -190,6 +219,23 @@ class Viewpoint implements CreateableInterface
             }
         }
         return null;
+    }
+
+    /**
+     * Checks if the viewpoint has a certain action group.
+     * @param string $actionGroupId
+     * @return bool
+     */
+    public function hasActionGroup(string $actionGroupId): bool
+    {
+        $groups = $this->getActionGroups();
+        foreach ($groups as $g) {
+            if ($g->getId() == $actionGroupId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Models/Viewpoint.php
+++ b/src/Models/Viewpoint.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Action;
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\SceneBasics;
+use LotGD\Core\Tools\SceneDescription;
 
 /**
  * A Viewpoint is the current Scene a character is experiencing with
@@ -32,6 +33,9 @@ class Viewpoint implements CreateableInterface
     /** @ManyToOne(targetEntity="Scene") */
     private $scene;
 
+    /** @var SceneDescription */
+    private $_description;
+
     /** @var array */
     private static $fillable = [
         "owner"
@@ -53,6 +57,39 @@ class Viewpoint implements CreateableInterface
     public function setOwner(Character $owner)
     {
         $this->owner = $owner;
+    }
+
+    /**
+     * Sets the description of this viewpoint.
+     * @param string $description
+     */
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+        $this->_description = new SceneDescription($description);
+    }
+
+    /**
+     * Returns the current description as a string
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Adds a paragraph to the existing description
+     * @param string $paragraph
+     */
+    public function addDescriptionParagraph(string $paragraph)
+    {
+        if ($this->_description === null) {
+            $this->_description = new SceneDescription($this->description);
+        }
+
+        $this->_description->addParagraph($paragraph);
+        $this->description = (string)$this->_description;
     }
 
     /**

--- a/src/Tools/SceneDescription.php
+++ b/src/Tools/SceneDescription.php
@@ -3,32 +3,59 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Tools;
 
-
+/**
+ * Abstracts a scene description and provides tools to modify the text more easily.
+ * Class SceneDescription
+ * @package LotGD\Core\Tools
+ */
 class SceneDescription
 {
     private $description = [];
 
+    /**
+     * SceneDescription constructor.
+     * @param string $description
+     */
     public function __construct(string $description)
     {
         $this->description = $this->splitIntoParagraphs($description);
     }
 
+    /**
+     * Converts the description to a string
+     * @return string
+     */
     public function __toString(): string
     {
         return $this->getDescriptionBack();
     }
 
+    /**
+     * Converts the description to a string.
+     * @return string
+     */
+    public function getDescriptionBack(): string
+    {
+        return implode("\n\n", $this->description);
+    }
+
+    /**
+     * Adds a paragraph to the description. If the paragraph contains \n\n, it gets broken into multiple paragraphs first.
+     * @param string $paragraph
+     */
     public function addParagraph(string $paragraph): void
     {
         $paragraph = $this->splitIntoParagraphs($paragraph);
         $this->description = array_merge($this->description, $paragraph);
     }
 
-    public function getDescriptionBack(): string
-    {
-        return implode("\n\n", $this->description);
-    }
-
+    /**
+     * Splits a given string into an array ("paragraphs")
+     *
+     * This method takes a string, normalizes line ends and then splits it at every double line break (\n\n).
+     * @param string $input
+     * @return array
+     */
     private function splitIntoParagraphs(string $input): array
     {
         $input = str_replace("\r\n", "\n", $input);

--- a/src/Tools/SceneDescription.php
+++ b/src/Tools/SceneDescription.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tools;
+
+
+class SceneDescription
+{
+    private $description = [];
+
+    public function __construct(string $description)
+    {
+        $this->description = $this->splitIntoParagraphs($description);
+    }
+
+    public function __toString(): string
+    {
+        return $this->getDescriptionBack();
+    }
+
+    public function addParagraph(string $paragraph): void
+    {
+        $paragraph = $this->splitIntoParagraphs($paragraph);
+        $this->description = array_merge($this->description, $paragraph);
+    }
+
+    public function getDescriptionBack(): string
+    {
+        return implode("\n\n", $this->description);
+    }
+
+    private function splitIntoParagraphs(string $input): array
+    {
+        $input = str_replace("\r\n", "\n", $input);
+        $input = str_replace("\r", "\n", $input);
+
+        return explode("\n\n", $input);
+    }
+}

--- a/tests/Models/ViewpointTest.php
+++ b/tests/Models/ViewpointTest.php
@@ -185,4 +185,16 @@ class ViewpointTest extends CoreModelTestCase
         $output->removeActionsWithSceneId(2);
         $this->assertEquals($actionGroupsWithout2, $output->getActionGroups());
     }
+
+    public function testChangingSceneDescription()
+    {
+        $em = $this->getEntityManager();
+        $testCharacter = $em->getRepository(Character::class)->find(2);
+        $characterScene = $testCharacter->getViewpoint();
+
+        $this->assertSame("This is the village.", $characterScene->getDescription());
+
+        $characterScene->addDescriptionParagraph("You enjoy being here.");
+        $this->assertSame("This is the village.\n\nYou enjoy being here.", $characterScene->getDescription());
+    }
 }


### PR DESCRIPTION
…ion more easily

As the title says. This patch enables to extend the viewpoint description more easily. Pure API sugar.

Before:
```php
$viewpoint->setDescription($viewpoint->getDescription() . "\n\nYou feel energized! You get back all your forest fights.");
```

After:
```php
$viewpoint->addDescriptionParagraph("You feel energized! You get back all your forest fights.");
```