### PR TITLE
Feature/extendable models

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace LotGD\Core;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\EventManager as DoctrineEventManager;
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\Events as DoctrineEvents;
 use Doctrine\ORM\ {
     EntityManager,
@@ -30,7 +32,8 @@ class Bootstrap
 {
     private $logger;
     private $game;
-    private $libraryConfigurationManager = [];
+    /** @var  LibraryConfigurationManager */
+    private $libraryConfigurationManager;
     private $annotationDirectories = [];
 
     /**
@@ -74,6 +77,9 @@ class Bootstrap
         // Add Event listener to entity manager
         $dem = $entityManager->getEventManager();
         $dem->addEventListener([DoctrineEvents::postLoad], new EntityPostLoadEventListener($this->game));
+
+        // Run model extender
+        $this->extendModels();
 
         return $this->game;
     }
@@ -200,6 +206,21 @@ class Bootstrap
             $commands = $config->getDaenerysCommands();
             foreach ($commands as $command) {
                 $application->add(new $command($this->game));
+            }
+        }
+    }
+
+    public function extendModels()
+    {
+        AnnotationRegistry::registerLoader("class_exists");
+
+        $modelExtender = new ModelExtender();
+
+        foreach ($this->libraryConfigurationManager->getConfigurations() as $config) {
+            $modelExtensions = $config->getSubKeyIfItExists(["modelExtensions"]);
+
+            if ($modelExtensions) {
+                $modelExtender->addMore($modelExtensions);
             }
         }
     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace LotGD\Core;
 
+use Doctrine\Common\EventManager as DoctrineEventManager;
+use Doctrine\ORM\Events as DoctrineEvents;
 use Doctrine\ORM\ {
     EntityManager,
     EntityManagerInterface,
@@ -17,10 +19,8 @@ use Monolog\ {
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 
-use LotGD\Core\ {
-    ComposerManager,
-    BootstrapInterface,
-    Exceptions\InvalidConfigurationException
+use LotGD\Core\{
+    ComposerManager, BootstrapInterface, Doctrine\EntityPostLoadEventListener, Exceptions\InvalidConfigurationException
 };
 
 /**
@@ -70,6 +70,10 @@ class Bootstrap
             ->withEntityManager($entityManager)
             ->withCwd($cwd)
             ->create();
+
+        // Add Event listener to entity manager
+        $dem = $entityManager->getEventManager();
+        $dem->addEventListener([DoctrineEvents::postLoad], new EntityPostLoadEventListener($this->game));
 
         return $this->game;
     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -210,6 +210,9 @@ class Bootstrap
         }
     }
 
+    /**
+     * Runs the code to extend models.
+     */
     public function extendModels()
     {
         AnnotationRegistry::registerLoader("class_exists");

--- a/src/Doctrine/Annotations/Extension.php
+++ b/src/Doctrine/Annotations/Extension.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Doctrine\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use LotGD\Core\Exceptions\ArgumentException;
+use LotGD\Core\Models\ExtendableModelInterface;
+
+/**
+ * Annotation that is used to flag which entity a class extends.
+ * @package LotGD\Core\Doctrine
+ * @Annotation
+ * @Target("CLASS")
+ * @Attributes({
+ *  @Attribute("of", type = "string")
+ * })
+ */
+class Extension
+{
+    /** @var string */
+    private $modelClass;
+
+    /**
+     * Extension constructor.
+     * @param array $attributes
+     * @throws ArgumentException
+     */
+    public function __construct(array $attributes) {
+        $this->modelClass = $attributes["of"];
+
+        if (!class_exists($this->modelClass)) {
+            throw new ArgumentException("The class given in of must be a valid class.");
+        }
+
+        if (!in_array(ExtendableModelInterface::class, class_implements($this->modelClass))) {
+            throw new ArgumentException("The class given in of must implement the ExtendableModelInterface.");
+        }
+    }
+
+    /**
+     * Returns the model class name.
+     * @return string
+     */
+    public function getModelClass(): string
+    {
+        return $this->modelClass;
+    }
+}

--- a/src/Doctrine/Annotations/ExtensionMethod.php
+++ b/src/Doctrine/Annotations/ExtensionMethod.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Doctrine\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use LotGD\Core\Exceptions\ArgumentException;
+
+/**
+ * Annotation that is used to link a static method to a model entity.
+ * @package LotGD\Core\Doctrine\Annotations
+ * @Annotation
+ * @Target("METHOD")
+ * @Attributes({
+ *  @Attribute("as", type = "string")
+ * })
+ */
+class ExtensionMethod
+{
+    /** @var string */
+    private $methodName = "";
+
+    /**
+     * ExtensionMethod constructor.
+     * @param array $attributes
+     * @throws ArgumentException
+     */
+    public function __construct(array $attributes) {
+        $this->methodName = $attributes["as"];
+
+        if (!is_string($this->methodName)) {
+            throw new ArgumentException("Property 'as' must be a string.");
+        }
+
+        if (strlen($this->methodName) == 0) {
+            throw new ArgumentException("Property 'as' must not be an empty string.");
+        }
+    }
+
+    /**
+     * Returns the method name.
+     * @return string
+     */
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+}

--- a/src/Doctrine/EntityPostLoadEventListener.php
+++ b/src/Doctrine/EntityPostLoadEventListener.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Doctrine;
+
+use Doctrine\Common\Util\Debug;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use LotGD\Core\Game;
+use LotGD\Core\GameAwareInterface;
+
+/**
+ * Class EntityPostLoadEventListener
+ * @package LotGD\Core\Doctrine
+ */
+class EntityPostLoadEventListener
+{
+    /** @var Game $game */
+    private $game;
+
+    public function __construct(Game $g)
+    {
+        $this->game = $g;
+    }
+
+    public function postLoad(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+        if ($entity instanceof GameAwareInterface) {
+            $entity->setGame($this->game);
+        }
+    }
+}

--- a/src/Doctrine/EntityPostLoadEventListener.php
+++ b/src/Doctrine/EntityPostLoadEventListener.php
@@ -17,11 +17,19 @@ class EntityPostLoadEventListener
     /** @var Game $game */
     private $game;
 
+    /**
+     * EntityPostLoadEventListener constructor.
+     * @param Game $g
+     */
     public function __construct(Game $g)
     {
         $this->game = $g;
     }
 
+    /**
+     * Called upon event postLoad.
+     * @param LifecycleEventArgs $args
+     */
     public function postLoad(LifecycleEventArgs $args)
     {
         $entity = $args->getEntity();

--- a/src/GameAwareInterface.php
+++ b/src/GameAwareInterface.php
@@ -10,4 +10,5 @@ namespace LotGD\Core;
 interface GameAwareInterface
 {
     public function setGame(Game $g);
+    public function getGame(): Game;
 }

--- a/src/GameAwareInterface.php
+++ b/src/GameAwareInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+/**
+ * Interface for classes that are aware of the game
+ * @package LotGD\Core
+ */
+interface GameAwareInterface
+{
+    public function setGame(Game $g);
+}

--- a/src/LibraryConfiguration.php
+++ b/src/LibraryConfiguration.php
@@ -126,7 +126,7 @@ class LibraryConfiguration
      * @param array $arguments
      * @return type
      */
-    protected function getSubKeyIfItExists(array $arguments)
+    public function getSubKeyIfItExists(array $arguments)
     {
         $parent = $this->rawConfig;
 
@@ -145,7 +145,7 @@ class LibraryConfiguration
      * Tries to iterate an array element given by the arguments
      * @param scalar $argument1,... array keys, by increasing depth
      */
-    protected function iterateKey(...$arguments)
+    public function iterateKey(...$arguments)
     {
         $result = $this->getSubKeyIfItExists($arguments);
 

--- a/src/LibraryConfiguration.php
+++ b/src/LibraryConfiguration.php
@@ -124,7 +124,7 @@ class LibraryConfiguration
     /**
      * Returns a subkey if it exists or null.
      * @param array $arguments
-     * @return type
+     * @return mixed
      */
     public function getSubKeyIfItExists(array $arguments)
     {

--- a/src/LibraryConfigurationManager.php
+++ b/src/LibraryConfigurationManager.php
@@ -52,7 +52,7 @@ class LibraryConfigurationManager
 
     /**
      * Return an array of the library configurations.
-     * @return array<LibraryConfiguration>
+     * @return LibraryConfiguration[]
      */
     public function getConfigurations(): array {
         return $this->configurations;

--- a/src/ModelExtender.php
+++ b/src/ModelExtender.php
@@ -10,11 +10,20 @@ use ReflectionClass;
 use Doctrine\Common\Annotations\AnnotationReader;
 use LotGD\Core\Doctrine\Annotations\Extension;
 
+/**
+ * Contains method to help the extension of a model.
+ * @package LotGD\Core
+ */
 class ModelExtender
 {
+    /** @var AnnotationReader */
     private $reader;
+    /** @var array */
     private static $classes = [];
 
+    /**
+     * ModelExtender constructor.
+     */
     public function __construct()
     {
         $this->reader = new AnnotationReader();
@@ -65,6 +74,12 @@ class ModelExtender
         }
     }
 
+    /**
+     * Returns a callback registered in the model extender globally.
+     * @param string $modelClassName
+     * @param string $methodName
+     * @return callable|null
+     */
     public static function get(string $modelClassName, string $methodName): ?callable
     {
         if (empty(self::$classes[$modelClassName])) {

--- a/src/ModelExtender.php
+++ b/src/ModelExtender.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+
+use LotGD\Core\Doctrine\Annotations\ExtensionMethod;
+use LotGD\Core\Exceptions\ArgumentException;
+use ReflectionClass;
+use Doctrine\Common\Annotations\AnnotationReader;
+use LotGD\Core\Doctrine\Annotations\Extension;
+
+class ModelExtender
+{
+    private $reader;
+    private static $classes = [];
+
+    public function __construct()
+    {
+        $this->reader = new AnnotationReader();
+    }
+
+    /**
+     * @param string[] $classes
+     */
+    public function addMore(array $classes): void {
+        foreach($classes as $class) {
+            $this->add($class);
+        }
+    }
+
+    /**
+     * @param string $class
+     * @throws ArgumentException if the given class is not properly annotated.
+     */
+    public function add(string $class): void
+    {
+        $reflectionClass = new ReflectionClass($class);
+        /** @var Extension $extensionAnnotation */
+        $extensionAnnotation = $this->reader->getClassAnnotation($reflectionClass, Extension::class);
+
+        if ($extensionAnnotation === null) {
+            throw new ArgumentException(sprintf("Class %s must have the class Annotation %s", $class, Extension::class));
+        }
+
+        $modelClass = $extensionAnnotation->getModelClass();
+
+        if (empty(self::$classes[$modelClass])) {
+            self::$classes[$modelClass] = [];
+        }
+
+        // Run through static methods
+        $reflectionMethods = $reflectionClass->getMethods();
+
+        foreach ($reflectionMethods as $method) {
+            if ($method->isStatic() === false) {
+                throw new ArgumentException(sprintf("Method %s must be static.", $method->getName()));
+            }
+
+            /** @var ExtensionMethod $extensionMethodAnnotation */
+            $extensionMethodAnnotation = $this->reader->getMethodAnnotation($method, ExtensionMethod::class);
+            $methodName = $method->getName();
+
+            self::$classes[$modelClass][$extensionMethodAnnotation->getMethodName()] = [$class, $methodName];
+        }
+    }
+
+    public static function get(string $modelClassName, string $methodName): ?callable
+    {
+        if (empty(self::$classes[$modelClassName])) {
+            return null;
+        }
+
+        if (empty(self::$classes[$modelClassName][$methodName])) {
+            return null;
+        }
+
+        return self::$classes[$modelClassName][$methodName];
+    }
+}

--- a/src/Models/Character.php
+++ b/src/Models/Character.php
@@ -11,14 +11,11 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
 use LotGD\Core\{
-    BuffList,
-    Game
+    BuffList, Game, GameAwareInterface
 };
 use LotGD\Core\Tools\Exceptions\BuffSlotOccupiedException;
 use LotGD\Core\Tools\Model\{
-    Creator,
-    PropertyManager,
-    SoftDeletable
+    Creator, GameAware, PropertyManager, SoftDeletable
 };
 
 /**
@@ -27,11 +24,12 @@ use LotGD\Core\Tools\Model\{
  * @Entity(repositoryClass="LotGD\Core\Models\Repositories\CharacterRepository")
  * @Table(name="characters")
  */
-class Character implements CharacterInterface, CreateableInterface
+class Character implements CharacterInterface, CreateableInterface, GameAwareInterface
 {
     use Creator;
     use SoftDeletable;
     use PropertyManager;
+    use GameAware;
 
     /** @Id @Column(type="integer") @GeneratedValue */
     private $id;

--- a/src/Models/ExtendableModelInterface.php
+++ b/src/Models/ExtendableModelInterface.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models;
+
+
+interface ExtendableModelInterface
+{
+    public function __call($method, $arguments);
+}

--- a/src/Tools/Model/ExtendableModel.php
+++ b/src/Tools/Model/ExtendableModel.php
@@ -5,6 +5,10 @@ namespace LotGD\Core\Tools\Model;
 
 use LotGD\Core\ModelExtender;
 
+/**
+ * Trait to add the __call class required for extendable models.
+ * @package LotGD\Core\Tools\Model
+ */
 trait ExtendableModel
 {
     public function __call($method, $arguments)

--- a/src/Tools/Model/ExtendableModel.php
+++ b/src/Tools/Model/ExtendableModel.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tools\Model;
+
+use LotGD\Core\ModelExtender;
+
+trait ExtendableModel
+{
+    public function __call($method, $arguments)
+    {
+        $callback = ModelExtender::get(self::class, $method);
+
+        if ($callback) {
+            return call_user_func_array($callback, array_merge([$this], $arguments));
+        }
+    }
+}

--- a/src/Tools/Model/GameAware.php
+++ b/src/Tools/Model/GameAware.php
@@ -18,7 +18,7 @@ trait GameAware
         $this->game = $game;
     }
 
-    private function getGame(): Game {
+    public function getGame(): Game {
         return $this->game;
     }
 }

--- a/src/Tools/Model/GameAware.php
+++ b/src/Tools/Model/GameAware.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tools\Model;
+
+
+use LotGD\Core\Game;
+
+/**
+ * Helper trait to implement public setGame from GameAwareInterface and private getGame for internal use.
+ * @package LotGD\Core\Tools\Model
+ */
+trait GameAware
+{
+    private $game;
+
+    public function setGame(Game $game) {
+        $this->game = $game;
+    }
+
+    private function getGame(): Game {
+        return $this->game;
+    }
+}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -150,5 +150,6 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $user = $game->getEntityManager()->getRepository(UserEntity::class)->find($id);
 
         $this->assertSame($game, $user->returnGame());
+        $this->assertSame([$user->getName()], $user->getNameAsArray());
     }
 }

--- a/tests/FakeModule/Models/UserEntity.php
+++ b/tests/FakeModule/Models/UserEntity.php
@@ -5,13 +5,18 @@ namespace LotGD\Core\Tests\FakeModule\Models;
 
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
+use LotGD\Core\Game;
+use LotGD\Core\GameAwareInterface;
+use LotGD\Core\Tools\Model\GameAware;
 
 /**
  * @Entity
  * @Table(name="Users")
  */
-class UserEntity
+class UserEntity implements GameAwareInterface
 {
+    use GameAware;
+
     /** @Id @Column(type="integer") @GeneratedValue */
     private $id;
     /** @Column(type="string", length=50); */
@@ -30,5 +35,10 @@ class UserEntity
     public function setName(string $name)
     {
         $this->name = $name;
+    }
+
+    public function returnGame(): Game
+    {
+        return $this->getGame();
     }
 }

--- a/tests/FakeModule/Models/UserEntity.php
+++ b/tests/FakeModule/Models/UserEntity.php
@@ -7,15 +7,18 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Game;
 use LotGD\Core\GameAwareInterface;
+use LotGD\Core\Models\ExtendableModelInterface;
+use LotGD\Core\Tools\Model\ExtendableModel;
 use LotGD\Core\Tools\Model\GameAware;
 
 /**
  * @Entity
  * @Table(name="Users")
  */
-class UserEntity implements GameAwareInterface
+class UserEntity implements GameAwareInterface, ExtendableModelInterface
 {
     use GameAware;
+    use ExtendableModel;
 
     /** @Id @Column(type="integer") @GeneratedValue */
     private $id;

--- a/tests/FakeModule/Models/UserTestExtension.php
+++ b/tests/FakeModule/Models/UserTestExtension.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests\FakeModule\Models;
+
+use LotGD\Core\Doctrine\Annotations\Extension;
+use LotGD\Core\Doctrine\Annotations\ExtensionMethod;
+use LotGD\Core\Models\Character;
+
+/**
+ * Class CharacterTestExtension
+ * @package LotGD\Core\Tests\FakeModule\Models
+ * @Extension(of="LotGD\Core\Tests\FakeModule\Models\UserEntity")
+ */
+class UserTestExtension
+{
+    /**
+     * @param UserEntity $user
+     * @return array
+     * @ExtensionMethod(as="getNameAsArray")
+     */
+    public static function returnNameAsArrayForUser(UserEntity $user): array
+    {
+        $g = $user->getGame();
+
+        if ($g !== null) {
+            return [$user->getName()];
+        } else {
+            return [];
+        }
+    }
+}

--- a/tests/FakeModule/lotgd.yml
+++ b/tests/FakeModule/lotgd.yml
@@ -1,3 +1,5 @@
 entityNamespace: "LotGD\\Core\\Tests\\FakeModule\\Models\\"
 subscriptionPatterns:
     - "e/lotgd/core/tests/event"
+modelExtensions:
+  - "LotGD\\Core\\Tests\\FakeModule\\Models\\UserTestExtension"


### PR DESCRIPTION
This branch contains the code to make models GameAware by making use of doctrine's postLoad event. It combines an interface (GameAwareInterface) with a trait (GameAware). Models implementing GameAwareInterface automatically get access to the public method `setGame` and `getGame`, both potentially needed for raising events within properties.

Furthermore, by combining a lotgd.yml configuration and annotations, this patch allows the easy runtime-modification of models by using the __call magic function. Example:

lotgd.yml:
```yaml
modelExtensions:
  - "LotGD\\Core\\Tests\\FakeModule\\Models\\UserTestExtension"
```

UserTestExtension:
```php
/**
 * @Extension(of="LotGD\Core\Tests\FakeModule\Models\UserEntity")
 */
class UserTestExtension
{
    /**
     * @ExtensionMethod(as="getNameAsArray")
     */
    public static function returnNameAsArrayForUser(UserEntity $user): array
    {
        $g = $user->getGame();

        if ($g !== null) {
            return [$user->getName()];
        } else {
            return [];
        }
    }
}
```

This allows me to write `$userEntity->getNameAsArray();`. Extentable models must implement the ExtendableModelInterface and are advised to use the ExtendableModel trait.
  