### PR TITLE
Hotfix for testing + fixes for version 7.2

### DIFF
--- a/src/ActionGroup.php
+++ b/src/ActionGroup.php
@@ -6,7 +6,7 @@ namespace LotGD\Core;
 /**
  * A grouping of navigation actions, like a submenu.
  */
-class ActionGroup
+class ActionGroup implements \Countable
 {
     const DefaultGroup = 'lotgd/core/default';
     const HiddenGroup = 'lotgd/core/hidden';
@@ -28,6 +28,15 @@ class ActionGroup
         $this->title = $title;
         $this->sortKey = $sortKey;
         $this->actions = [];
+    }
+
+    /**
+     * Returns the number of registered Actions for this group.
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->actions);
     }
 
     /**

--- a/src/Game.php
+++ b/src/Game.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace LotGD\Core;
 
 use DateTime;
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\EntityManagerInterface;
 use LotGD\Core\Events\NavigateToSceneData;
 use LotGD\Core\Events\NewViewpointData;

--- a/src/Models/Repositories/CharacterRepository.php
+++ b/src/Models/Repositories/CharacterRepository.php
@@ -45,7 +45,7 @@ class CharacterRepository extends EntityRepository
     /**
      * Find a character by ID.
      */
-    public function find($id, int $deletes = self::SKIP_SOFTDELETED)
+    public function find($id, $lockMode = NULL, $lockVersion = NULL, int $deletes = self::SKIP_SOFTDELETED)
     {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
         $queryBuilder->select("c")

--- a/src/Models/Repositories/MessageThreadRepository.php
+++ b/src/Models/Repositories/MessageThreadRepository.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace LotGD\Core\Models\Repositories;
 
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;

--- a/t
+++ b/t
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
-phpunit --stop-on-failure
+./vendor/bin/phpunit --stop-on-failure
 ./vendor/bin/phpdoccheck -d src --no-ansi

--- a/tests/Models/MessageModelTest.php
+++ b/tests/Models/MessageModelTest.php
@@ -64,7 +64,7 @@ class MessageModelTest extends CoreModelTestCase
 
         $character1 = $em->getRepository(Character::class)->find(1);
         $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->find(3, CharacterRepository::INCLUDE_SOFTDELETED);
+        $character3 = $em->getRepository(Character::class)->find(3, NULL, NULL, CharacterRepository::INCLUDE_SOFTDELETED);
         $character4 = $em->getRepository(Character::class)->find(4);
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);
@@ -92,7 +92,7 @@ class MessageModelTest extends CoreModelTestCase
         
         $character1 = $em->getRepository(Character::class)->find(1);
         $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->find(3, CharacterRepository::INCLUDE_SOFTDELETED);
+        $character3 = $em->getRepository(Character::class)->find(3, NULL, NULL, CharacterRepository::INCLUDE_SOFTDELETED);
         $character4 = $em->getRepository(Character::class)->find(4);
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);


### PR DESCRIPTION
This is a hotfix for testing. PHPUnit 6 and 7 do not recognize PHPUnit 5.7-type tests, thus it exits with exitcode 0 (= no failed tests). This allows merging of pull requests without proper testing.

While fixing this, travis reported 2 new errors in combination with PHP 7.2 dependencies which this hotfix also fixes to get "travis greenlight".