### PR TITLE
Graceful recovery from module registration failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "monolog/monolog": "^1.12",
         "symfony/console": "^3.0",
         "symfony/yaml": "^3.0",
-        "d11wtq/boris": "^1.0"
+        "d11wtq/boris": "^1.0",
+        "ramsey/uuid-doctrine": "^1.5"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "17f21a2b00ed3688642b239f27762dcf",
-    "content-hash": "3cc588e6b12f6a9f36d2ca32969d996b",
+    "hash": "0419f6d36248a11755819feead450f80",
+    "content-hash": "9663d004ab08338fb0640f807e3c2b94",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -53,16 +53,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "943b2c4fcad1ef178d16a713c2468bf7e579c288"
+                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/943b2c4fcad1ef178d16a713c2468bf7e579c288",
-                "reference": "943b2c4fcad1ef178d16a713c2468bf7e579c288",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/46afded9720f40b9dc63542af4e3e43a1177acb0",
+                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
                 "psr/log": "^1.0",
                 "symfony/process": "^2.5 || ^3.0 || ^4.0"
             },
@@ -105,39 +105,42 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-11-29 09:37:33"
+            "time": "2018-08-08 08:57:40"
         },
         {
             "name": "composer/composer",
-            "version": "1.5.6",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "4f7f9c12753ec43f1e4629e2a71cabe81f2a4eab"
+                "reference": "576aab9b5abb2ed11a1c52353a759363216a4ad2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/4f7f9c12753ec43f1e4629e2a71cabe81f2a4eab",
-                "reference": "4f7f9c12753ec43f1e4629e2a71cabe81f2a4eab",
+                "url": "https://api.github.com/repos/composer/composer/zipball/576aab9b5abb2ed11a1c52353a759363216a4ad2",
+                "reference": "576aab9b5abb2ed11a1c52353a759363216a4ad2",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0",
                 "composer/semver": "^1.0",
-                "composer/spdx-licenses": "^1.0",
+                "composer/spdx-licenses": "^1.2",
+                "composer/xdebug-handler": "^1.1",
                 "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
                 "php": "^5.3.2 || ^7.0",
                 "psr/log": "^1.0",
-                "seld/cli-prompt": "^1.0",
                 "seld/jsonlint": "^1.4",
                 "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.7 || ^3.0",
-                "symfony/filesystem": "^2.7 || ^3.0",
-                "symfony/finder": "^2.7 || ^3.0",
-                "symfony/process": "^2.7 || ^3.0"
+                "symfony/console": "^2.7 || ^3.0 || ^4.0",
+                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
+                "symfony/finder": "^2.7 || ^3.0 || ^4.0",
+                "symfony/process": "^2.7 || ^3.0 || ^4.0"
+            },
+            "conflict": {
+                "symfony/console": "2.8.38"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
             },
             "suggest": {
@@ -151,7 +154,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -182,7 +185,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2017-12-18 11:09:18"
+            "time": "2018-08-16 14:57:12"
         },
         {
             "name": "composer/semver",
@@ -248,23 +251,23 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.1.6",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c"
+                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
-                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/cb17687e9f936acd7e7245ad3890f953770dec1b",
+                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
                 "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
             },
             "type": "library",
@@ -305,7 +308,51 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2017-04-03 19:08:52"
+            "time": "2018-04-30 10:33:04"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2018-08-31 19:07:57"
         },
         {
             "name": "d11wtq/boris",
@@ -413,16 +460,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.7.1",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
-                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
                 "shasum": ""
             },
             "require": {
@@ -433,8 +480,9 @@
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
                 "mongodb/mongodb": "^1.1",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^7.0",
                 "predis/predis": "~1.0"
             },
             "suggest": {
@@ -443,7 +491,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -478,12 +526,12 @@
                 }
             ],
             "description": "Caching library offering an object-oriented API for many cache backends",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org",
             "keywords": [
                 "cache",
                 "caching"
             ],
-            "time": "2017-08-25 07:02:50"
+            "time": "2018-08-21 18:01:43"
         },
         {
             "name": "doctrine/collections",
@@ -700,20 +748,20 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
-                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.2"
@@ -721,7 +769,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -763,7 +811,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2017-07-22 12:18:28"
+            "time": "2018-01-09 20:05:19"
         },
         {
             "name": "doctrine/instantiator",
@@ -951,16 +999,16 @@
         },
         {
             "name": "gedmo/doctrine-extensions",
-            "version": "v2.4.31",
+            "version": "v2.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
-                "reference": "79cd1d49898a21ede9a5dfad41c021abd9a14339"
+                "reference": "87c78ff9fd4b90460386f753d95622f6fbbfcb27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/79cd1d49898a21ede9a5dfad41c021abd9a14339",
-                "reference": "79cd1d49898a21ede9a5dfad41c021abd9a14339",
+                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/87c78ff9fd4b90460386f753d95622f6fbbfcb27",
+                "reference": "87c78ff9fd4b90460386f753d95622f6fbbfcb27",
                 "shasum": ""
             },
             "require": {
@@ -968,12 +1016,15 @@
                 "doctrine/common": "~2.4",
                 "php": ">=5.3.2"
             },
+            "conflict": {
+                "doctrine/annotations": "<1.2"
+            },
             "require-dev": {
                 "doctrine/common": ">=2.5.0",
                 "doctrine/mongodb-odm": ">=1.0.2",
                 "doctrine/orm": ">=2.5.0",
-                "phpunit/phpunit": "*",
-                "symfony/yaml": "~2.6|~3.0"
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.5",
+                "symfony/yaml": "~2.6|~3.0|~4.0"
             },
             "suggest": {
                 "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",
@@ -986,8 +1037,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Gedmo\\": "lib/"
+                "psr-4": {
+                    "Gedmo\\": "lib/Gedmo"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1025,20 +1076,20 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2017-10-12 06:26:21"
+            "time": "2018-07-26 12:16:35"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.6",
+            "version": "5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd"
+                "reference": "8560d4314577199ba51bf2032f02cd1315587c23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/d283e11b6e14c6f4664cf080415c4341293e5bbd",
-                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/8560d4314577199ba51bf2032f02cd1315587c23",
+                "reference": "8560d4314577199ba51bf2032f02cd1315587c23",
                 "shasum": ""
             },
             "require": {
@@ -1047,7 +1098,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.1",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.22"
+                "phpunit/phpunit": "^4.8.35"
             },
             "bin": [
                 "bin/validate-json"
@@ -1091,7 +1142,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-10-21 13:15:38"
+            "time": "2018-02-14 22:26:30"
         },
         {
             "name": "monolog/monolog",
@@ -1219,72 +1270,24 @@
             "time": "2016-10-10 12:19:37"
         },
         {
-            "name": "seld/cli-prompt",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/cli-prompt.git",
-                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
-                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Seld\\CliPrompt\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
-            "keywords": [
-                "cli",
-                "console",
-                "hidden",
-                "input",
-                "prompt"
-            ],
-            "time": "2017-03-18 11:32:45"
-        },
-        {
             "name": "seld/jsonlint",
-            "version": "1.6.2",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19"
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
-                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "bin": [
                 "bin/jsonlint"
@@ -1313,7 +1316,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-11-30 15:34:22"
+            "time": "2018-01-24 12:46:19"
         },
         {
             "name": "seld/phar-utils",
@@ -1361,16 +1364,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.2",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9f21adfb92a9315b73ae2ed43138988ee4913d4e"
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9f21adfb92a9315b73ae2ed43138988ee4913d4e",
-                "reference": "9f21adfb92a9315b73ae2ed43138988ee4913d4e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
                 "shasum": ""
             },
             "require": {
@@ -1391,7 +1394,7 @@
                 "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -1426,20 +1429,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-10-02 16:33:53"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.0.2",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "8c3e709209ce3b952a31c0f4a31ac7703c3d0226"
+                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/8c3e709209ce3b952a31c0f4a31ac7703c3d0226",
-                "reference": "8c3e709209ce3b952a31c0f4a31ac7703c3d0226",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
+                "reference": "e3f76ce6198f81994e019bb2b4e533e9de1b9b90",
                 "shasum": ""
             },
             "require": {
@@ -1455,7 +1458,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1482,29 +1485,30 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-12 08:41:51"
+            "time": "2018-10-02 16:36:10"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.2",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "25b135bea251829e3db6a77d773643408b575ed4"
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/25b135bea251829e3db6a77d773643408b575ed4",
-                "reference": "25b135bea251829e3db6a77d773643408b575ed4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/596d12b40624055c300c8b619755b748ca5cf0b5",
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1531,29 +1535,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-10-02 12:40:59"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.2",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a"
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/dac8d7db537bac7ad8143eb11360a8c2231f251a",
-                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/1f17195b44543017a9c9b2d437c670627e96ad06",
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1580,20 +1584,78 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05 16:10:10"
+            "time": "2018-10-03 08:47:56"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.6.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06 14:22:27"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -1605,7 +1667,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -1639,29 +1701,29 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2018-08-06 14:22:27"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.2",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "bb3ef65d493a6d57297cad6c560ee04e2a8f5098"
+                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/bb3ef65d493a6d57297cad6c560ee04e2a8f5098",
-                "reference": "bb3ef65d493a6d57297cad6c560ee04e2a8f5098",
+                "url": "https://api.github.com/repos/symfony/process/zipball/ee33c0322a8fee0855afcc11fff81e6b1011b529",
+                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1688,24 +1750,25 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-10-02 12:40:59"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.2",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "afe0cd38486505c9703707707d91450cfc1bd536"
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/afe0cd38486505c9703707707d91450cfc1bd536",
-                "reference": "afe0cd38486505c9703707707d91450cfc1bd536",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/640b6c27fed4066d64b64d5903a86043f4a4de7f",
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -1746,7 +1809,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-11 20:38:23"
+            "time": "2018-10-02 16:33:53"
         }
     ],
     "packages-dev": [
@@ -1803,25 +1866,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -1844,7 +1910,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19 19:58:43"
+            "time": "2018-06-11 23:09:50"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1902,16 +1968,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -1949,7 +2015,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27 17:38:31"
+            "time": "2017-11-30 07:14:17"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2000,33 +2066,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -2059,7 +2125,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24 13:59:53"
+            "time": "2018-08-05 17:53:17"
         },
         {
             "name": "phpunit/dbunit",
@@ -2367,16 +2433,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.26",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd",
-                "reference": "7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -2400,7 +2466,7 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
                 "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
@@ -2445,7 +2511,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-17 06:14:38"
+            "time": "2018-02-01 05:50:59"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3021,16 +3087,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -3067,7 +3133,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2018-01-29 19:49:41"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0419f6d36248a11755819feead450f80",
-    "content-hash": "9663d004ab08338fb0640f807e3c2b94",
+    "hash": "9ce66e946e56f62ed759f6c046f18cae",
+    "content-hash": "5cb12bb017ac481f9d95f41a08ea4a76",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1223,6 +1223,51 @@
             "time": "2017-06-19 01:22:40"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02 15:55:56"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -1268,6 +1313,145 @@
                 "psr-3"
             ],
             "time": "2016-10-10 12:19:37"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1.0|^2.0|9.99.99",
+                "php": "^5.4 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^1.0 | ~2.0.0",
+                "doctrine/annotations": "~1.2.0",
+                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ~2.1.0",
+                "ircmaxell/random-lib": "^1.1",
+                "jakub-onderka/php-parallel-lint": "^0.9.0",
+                "mockery/mockery": "^0.9.9",
+                "moontoast/math": "^1.1",
+                "php-mock/php-mock-phpunit": "^0.3|^1.1",
+                "phpunit/phpunit": "^4.7|^5.0|^6.5",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "suggest": {
+                "ext-ctype": "Provides support for PHP Ctype functions",
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2018-07-19 23:38:55"
+        },
+        {
+            "name": "ramsey/uuid-doctrine",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid-doctrine.git",
+                "reference": "2a56db8e68bff487508244f5a2008075279d0255"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid-doctrine/zipball/2a56db8e68bff487508244f5a2008075279d0255",
+                "reference": "2a56db8e68bff487508244f5a2008075279d0255",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/orm": "^2.5",
+                "php": "^5.4 || ^7.0",
+                "ramsey/uuid": "^3.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "mockery/mockery": "^0.9 || ^1.1",
+                "php-coveralls/php-coveralls": "^1.1 || ^2.1",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\Doctrine\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "http://benramsey.com"
+                }
+            ],
+            "description": "Allow the use of a ramsey/uuid UUID as Doctrine field type.",
+            "homepage": "https://github.com/ramsey/uuid-doctrine",
+            "keywords": [
+                "doctrine",
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2018-08-11 21:01:22"
         },
         {
             "name": "seld/jsonlint",

--- a/src/Action.php
+++ b/src/Action.php
@@ -20,7 +20,7 @@ class Action
      * @param string|null $title
      * @param array $parameters
      */
-    public function __construct(int $destinationSceneId, ?string $title = null, array $parameters = [])
+    public function __construct(string $destinationSceneId, ?string $title = null, array $parameters = [])
     {
         $this->id = bin2hex(random_bytes(8));
         $this->destinationSceneId = $destinationSceneId;
@@ -43,7 +43,7 @@ class Action
      * go if they take this action.
      * @return int
      */
-    public function getDestinationSceneId(): int
+    public function getDestinationSceneId(): string
     {
         return $this->destinationSceneId;
     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -6,6 +6,7 @@ namespace LotGD\Core;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\EventManager as DoctrineEventManager;
 use Doctrine\Common\Util\Debug;
+use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\Events as DoctrineEvents;
 use Doctrine\ORM\ {
     EntityManager,
@@ -172,6 +173,11 @@ class Bootstrap
 
         // Create entity manager
         $entityManager = EntityManager::create(["pdo" => $pdo], $configuration);
+
+        // Register uuid type
+        try {
+            \Doctrine\DBAL\Types\Type::addType('uuid', 'Ramsey\Uuid\Doctrine\UuidType');
+        } catch (DBALException $e) {}
 
         // Create Schema and update database if needed
         $metaData = $entityManager->getMetadataFactory()->getAllMetadata();

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -111,7 +111,8 @@ class EventManager
             'class' => $class,
             'library' => $library
         ]);
-        $e->save($this->g->getEntityManager());
+
+        $this->g->getEntityManager()->persist($e);
     }
 
     /**

--- a/src/Models/BasicEnemy.php
+++ b/src/Models/BasicEnemy.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 namespace LotGD\Core\Models;
 
 use Doctrine\ORM\Mapping\MappedSuperclass;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @MappedSuperclass
  */
 abstract class BasicEnemy implements FighterInterface
 {
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /** @Id @Column(type="uuid", unique=True) */
     protected $id;
     /** @Column(type="string", length=50); */
     protected $name;
@@ -18,12 +20,20 @@ abstract class BasicEnemy implements FighterInterface
     protected $level;
     /** @var int */
     protected $health;
+
+    /**
+     * BasicEnemy constructor. Sets uuid upon creation.
+     * @throws \Exception
+     */
+    public function __construct() {
+        $this->id = Uuid::uuid4();
+    }
     
     /**
      * Returns the enemy's id
      * @return int
      */
-    public function getId(): int
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Models/Buff.php
+++ b/src/Models/Buff.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 
 use LotGD\Core\Exceptions\ArgumentException;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * A model representing a buff used to modify the flow of the battle.
@@ -23,7 +25,7 @@ class Buff
     const ACTIVATE_NONE = 0b0000;
     const ACTIVATE_ANY = 0b1111;
     
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /** @Id @Column(type="uuid", unique=True) */
     private $id;
     /**
      * @ManyToOne(targetEntity="Character", inversedBy="buffs")
@@ -231,7 +233,7 @@ class Buff
      * Allowed buff values and their type
      * @var array
      */
-    private $buffArrayTemplate = [
+    private static $buffArrayTemplate = [
         "slot" => "string",
         "name" => "string",
         "startMessage" => "string",
@@ -282,13 +284,15 @@ class Buff
      */
     public function __construct(array $buffArray)
     {
+        $this->id = Uuid::uuid4();
+
         foreach ($buffArray as $attribute => $value) {
             // Throw exception if an attribute does not exist (to prevent spelling errors)
-            if (!isset($this->buffArrayTemplate[$attribute])) {
+            if (!isset(self::$buffArrayTemplate[$attribute])) {
                 throw new ArgumentException("{$attribute} is not a valid key for a buff.");
             }
             
-            switch ($this->buffArrayTemplate[$attribute]) {
+            switch (self::$buffArrayTemplate[$attribute]) {
                 case "string":
                     if (is_string($value) === false) {
                         throw new ArgumentException("{$attribute} needs to be a string.");
@@ -338,7 +342,7 @@ class Buff
     {
         $buffArray = [];
         
-        foreach ($this->buffArrayTemplate as $attribute => $type) {
+        foreach (self::$buffArrayTemplate as $attribute => $type) {
             $buffArray[$attribute] = $buff->$attribute;
         }
         
@@ -349,7 +353,7 @@ class Buff
      * Returns the id of the buff
      * @return int
      */
-    public function getId(): int
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Models/Character.php
+++ b/src/Models/Character.php
@@ -17,6 +17,8 @@ use LotGD\Core\Exceptions\BuffSlotOccupiedException;
 use LotGD\Core\Tools\Model\{
     Creator, ExtendableModel, GameAware, PropertyManager, SoftDeletable
 };
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Model for a character
@@ -32,7 +34,7 @@ class Character implements CharacterInterface, CreateableInterface, GameAwareInt
     use GameAware;
     use ExtendableModel;
 
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /** @Id @Column(type="uuid", unique=True) */
     private $id;
     /** @Column(type="string", length=50); */
     private $name;
@@ -90,6 +92,8 @@ class Character implements CharacterInterface, CreateableInterface, GameAwareInt
      */
     public function __construct()
     {
+        $this->id = Uuid::uuid4();
+
         $this->properties = new ArrayCollection();
         $this->buffs = new ArrayCollection();
         $this->messageThreads = new ArrayCollection();
@@ -99,7 +103,7 @@ class Character implements CharacterInterface, CreateableInterface, GameAwareInt
      * Returns the entity's id
      * @return int The id
      */
-    public function getId(): int
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Models/CharacterInterface.php
+++ b/src/Models/CharacterInterface.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Models;
 
+use Ramsey\Uuid\UuidInterface;
+
 /**
  * Interface for the character model and all objects that mimick such a model.
  */
 interface CharacterInterface extends FighterInterface
 {
-    public function getId(): int;
+    public function getId(): UuidInterface;
     public function getName(): string;
     public function getDisplayName(): string;
     public function getHealth(): int;

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -39,9 +39,6 @@ class Message
     private $systemMessage = false;
     
 
-    
-
-    
     /**
      * Constructs the message.
      * Use the Message Manager methods send() and sendSystemMessage() instead.

--- a/src/Models/MotD.php
+++ b/src/Models/MotD.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\Mapping\Table;
 
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\Deletor;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Model for the message of the day
@@ -20,7 +22,7 @@ class MotD implements CreateableInterface
     use Creator;
     use Deletor;
     
-    /** @Id @Column(type="integer") @GeneratedValue */
+    /** @Id @Column(type="uuid", unique=True) */
     private $id;
     /**
      * @ManyToOne(targetEntity="Character", cascade={"persist"}, fetch="EAGER")
@@ -49,6 +51,7 @@ class MotD implements CreateableInterface
      */
     public function __construct()
     {
+        $this->id = Uuid::uuid4();
         $this->creationTime = new \DateTime("now");
     }
     
@@ -56,7 +59,7 @@ class MotD implements CreateableInterface
      * Returns the entities ID
      * @return int
      */
-    public function getId(): int
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Models/Repositories/CharacterRepository.php
+++ b/src/Models/Repositories/CharacterRepository.php
@@ -43,7 +43,7 @@ class CharacterRepository extends EntityRepository
     }
 
     /**
-     * Find a character by ID.
+     * Find a character by ID, excluding soft deleted ones.
      */
     public function find($id, $lockMode=null, $lockVersion=null)
     {
@@ -62,6 +62,12 @@ class CharacterRepository extends EntityRepository
         }
     }
 
+    /**
+     * Finds a character id ID, including soft deleted ones.
+     * @param $id
+     * @return mixed|null
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function findWithSoftDeleted($id) {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
         $queryBuilder->select("c")

--- a/src/Models/Repositories/CharacterRepository.php
+++ b/src/Models/Repositories/CharacterRepository.php
@@ -45,7 +45,7 @@ class CharacterRepository extends EntityRepository
     /**
      * Find a character by ID.
      */
-    public function find($id, $lockMode = NULL, $lockVersion = NULL, int $deletes = self::SKIP_SOFTDELETED)
+    public function find($id, $lockMode=null, $lockVersion=null)
     {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
         $queryBuilder->select("c")
@@ -53,7 +53,23 @@ class CharacterRepository extends EntityRepository
             ->where($queryBuilder->expr()->eq("c.id", ":id"))
             ->setParameter("id", $id);
 
-        $this->modifyQuery($queryBuilder, $deletes);
+        $this->modifyQuery($queryBuilder, self::SKIP_SOFTDELETED);
+
+        try {
+            return $queryBuilder->getQuery()->getSingleResult();
+        } catch (NoResultException $e) {
+            return null;
+        }
+    }
+
+    public function findWithSoftDeleted($id) {
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+        $queryBuilder->select("c")
+            ->from(Character::class, "c")
+            ->where($queryBuilder->expr()->eq("c.id", ":id"))
+            ->setParameter("id", $id);
+
+        $this->modifyQuery($queryBuilder, self::INCLUDE_SOFTDELETED);
 
         try {
             return $queryBuilder->getQuery()->getSingleResult();

--- a/src/Models/Repositories/MessageThreadRepository.php
+++ b/src/Models/Repositories/MessageThreadRepository.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace LotGD\Core\Models\Repositories;
 
-use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Models/Repositories/MessageThreadRepository.php
+++ b/src/Models/Repositories/MessageThreadRepository.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace LotGD\Core\Models\Repositories;
 
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Models/Scene.php
+++ b/src/Models/Scene.php
@@ -12,6 +12,8 @@ use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Tools\Model\Creator;
 use LotGD\Core\Tools\Model\Deletor;
 use LotGD\Core\Tools\Model\SceneBasics;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * A scene is a location within the game, such as the Village or the Tavern. Designed
@@ -26,8 +28,8 @@ class Scene implements CreateableInterface, SceneConnectable
     use Deletor;
     use SceneBasics;
 
-    /** @Id @Column(type="integer") @GeneratedValue */
-    private $id;
+    /** @Id @Column(type="string", length=36, unique=True, name="id", options={"fixed" = true}) */
+    protected $id;
 
     /**
      * @OneToMany(targetEntity="SceneConnectionGroup", mappedBy="scene", cascade={"persist", "remove"})
@@ -61,6 +63,8 @@ class Scene implements CreateableInterface, SceneConnectable
      */
     public function __construct()
     {
+        $this->id = Uuid::uuid4()->toString();
+
         $this->connectionGroups = new ArrayCollection();
         $this->outgoingConnections = new ArrayCollection();
         $this->incomingConnections = new ArrayCollection();
@@ -70,7 +74,7 @@ class Scene implements CreateableInterface, SceneConnectable
      * Returns the primary ID for this scene.
      * @return int
      */
-    public function getId(): int
+    public function getId(): string
     {
         return $this->id;
     }

--- a/src/Models/SceneConnection.php
+++ b/src/Models/SceneConnection.php
@@ -15,14 +15,14 @@ class SceneConnection
 {
     /**
      * @Id
-     * @ManyToOne(targetEntity="Scene")
+     * @ManyToOne(targetEntity="Scene", inversedBy="outgoingConnections")
      * @JoinColumn(name="outgoingScene", referencedColumnName="id")
      */
     private $outgoingScene;
 
     /**
      * @Id
-     * @ManyToOne(targetEntity="Scene")
+     * @ManyToOne(targetEntity="Scene", inversedBy="incomingConnections")
      * @JoinColumn(name="incomingScene", referencedColumnName="id")
      */
     private $incomingScene;

--- a/src/Models/Viewpoint.php
+++ b/src/Models/Viewpoint.php
@@ -329,7 +329,7 @@ class Viewpoint implements CreateableInterface
      * Removes any actions that correspond to a given scene ID, if present.
      * @param int $id
      */
-    public function removeActionsWithSceneId(int $id)
+    public function removeActionsWithSceneId(string $id)
     {
         foreach ($this->getActionGroups() as $group) {
             $actions = $group->getActions();

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -79,7 +79,8 @@ class ModuleManager
 
             try {
                 $class::onRegister($this->g, $m);
-                $m->save($this->g->getEntityManager());
+                $this->g->getEntityManager()->persist($m);
+                $this->g->getEntityManager()->flush();
             } catch (Throwable $e) {
                 $this->g->getLogger()->error("Calling {$class}::onRegister failed with exception: {$e->getMessage()}");
                 unset($m);

--- a/src/Tools/Model/MockCharacter.php
+++ b/src/Tools/Model/MockCharacter.php
@@ -10,6 +10,7 @@ use LotGD\Core\{
 };
 use LotGD\Core\Exceptions\IsNullException;
 use LotGD\Core\Models\Viewpoint;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Provides basic implementation to mock CharacterInterface.
@@ -21,7 +22,7 @@ trait MockCharacter
         throw new IsNullException();
     }
 
-    public function getId(): int
+    public function getId(): UuidInterface
     {
         throw new IsNullException();
     }

--- a/tests/BattleTest.php
+++ b/tests/BattleTest.php
@@ -5,6 +5,7 @@ namespace LotGD\Core\Tests\Models;
 
 use Doctrine\Common\Collections\Collection;
 
+use Doctrine\Common\Util\Debug;
 use LotGD\Core\{
     Battle,
     DiceBag,
@@ -25,6 +26,9 @@ use LotGD\Core\Models\BattleEvents\{
 };
 
 use LotGD\Core\Tests\CoreModelTestCase;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidFactory;
 
 class BattleTest extends CoreModelTestCase
 {
@@ -52,8 +56,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $this->assertSame(5, $monster->getLevel());
         $this->assertSame(52, $monster->getMaxHealth());
@@ -69,8 +73,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $battle = new Battle($this->getMockGame($character), $character, $monster);
 
@@ -106,8 +110,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $battle = new Battle($this->getMockGame($character), $character, $monster);
         $battle = $battle->serialize();
@@ -139,8 +143,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $highLevelPlayer = $em->getRepository(Character::class)->find(2);
-        $lowLevelMonster = $em->getRepository(Monster::class)->find(3);
+        $highLevelPlayer = $em->getRepository(Character::class)->find("4d01c29b-d825-4bc7-9e6e-63525155fd37");
+        $lowLevelMonster = $em->getRepository(Monster::class)->find("c004bcb6-a7c1-4f9a-abc2-1711c64e23a0");
 
         $battle = new Battle($this->getMockGame($highLevelPlayer), $highLevelPlayer, $lowLevelMonster);
 
@@ -172,8 +176,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $lowLevelPlayer = $em->getRepository(Character::class)->find(3);
-        $highLevelMonster = $em->getRepository(Monster::class)->find(2);
+        $lowLevelPlayer = $em->getRepository(Character::class)->find("c3792b61-4e34-4710-9871-65a68ac30bb4");
+        $highLevelMonster = $em->getRepository(Monster::class)->find("b636df29-f72d-4e2d-9850-982e783a9e94");
 
         $battle = new Battle($this->getMockGame($lowLevelPlayer), $lowLevelPlayer, $highLevelMonster);
 
@@ -205,8 +209,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $battle = new Battle($this->getMockGame($character), $character, $monster);
 
@@ -220,8 +224,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $battle = new Battle($this->getMockGame($character), $character, $monster);
 
@@ -236,8 +240,8 @@ class BattleTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $character = $em->getRepository(Character::class)->find(1);
-        $monster = $em->getRepository(Monster::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+        $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
 
         $battle = new Battle($this->getMockGame($character), $character, $monster);
 
@@ -257,23 +261,23 @@ class BattleTest extends CoreModelTestCase
             default:
             case 0:
                 // Fair Battle
-                $character = $em->getRepository(Character::class)->find(1);
-                $monster = $em->getRepository(Monster::class)->find(1);
+                $character = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
+                $monster = $em->getRepository(Monster::class)->find("de84c507-9673-44e7-b665-9e43416b9c2f");
                 break;
             case 1:
                 // very long battle
-                $character = $em->getRepository(Character::class)->find(4);
-                $monster = $em->getRepository(Monster::class)->find(3);
+                $character = $em->getRepository(Character::class)->find("6565b418-55f5-4a6b-8d92-a9ef81329912");
+                $monster = $em->getRepository(Monster::class)->find("c004bcb6-a7c1-4f9a-abc2-1711c64e23a0");
                 break;
             case 2:
                 // player should win battle
-                $character = $em->getRepository(Character::class)->find(13);
-                $monster = $em->getRepository(Monster::class)->find(11);
+                $character = $em->getRepository(Character::class)->find("1a9f63f2-3006-4e12-b272-4fd6be518a93");
+                $monster = $em->getRepository(Monster::class)->find("7ca9c141-aaf8-44a5-9d04-b6f9923f3c66");
                 break;
             case 3:
                 // player should lose battle
-                $character = $em->getRepository(Character::class)->find(11);
-                $monster = $em->getRepository(Monster::class)->find(13);
+                $character = $em->getRepository(Character::class)->find("24d71c26-f915-401c-8b3e-1932edf650ce");
+                $monster = $em->getRepository(Monster::class)->find("09540b93-63c9-4d82-8501-f569f63dfc4c");
                 break;
         }
 
@@ -1331,7 +1335,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistGoodguyAttackModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([
@@ -1360,7 +1364,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistGoodguyDefenseModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([
@@ -1389,7 +1393,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistGoodguyDamageModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([
@@ -1418,7 +1422,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistBadguyAttackModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([
@@ -1447,7 +1451,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistBadguyDefenseModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([
@@ -1476,7 +1480,7 @@ class BattleTest extends CoreModelTestCase
     public function testBufflistBadguyDamageModifier()
     {
         $em = $this->getEntityManager();
-        $player = $em->getRepository(Character::class)->find(1);
+        $player = $em->getRepository(Character::class)->find("d363c077-234a-433d-834e-f1a1d3b281d8");
         $game = $this->getMockGame($player);
 
         $player->addBuff(new Buff([

--- a/tests/DefectiveModule/Module.php
+++ b/tests/DefectiveModule/Module.php
@@ -5,6 +5,7 @@ namespace LotGD\Core\Tests\DefectiveModule;
 use LotGD\Core\Exceptions\CoreException;
 use LotGD\Core\Game;
 use LotGD\Core\Events\EventContext;
+use LotGD\Core\Models\Character;
 use LotGD\Core\Module as ModuleInterface;
 use LotGD\Core\Models\Module as ModuleModel;
 
@@ -18,6 +19,9 @@ class Module implements ModuleInterface {
 
     public static function onRegister(Game $g, ModuleModel $module)
     {
+        $character = Character::create(["name" => "Test"]);
+        $character->save($g->getEntityManager());
+
         throw new DefectiveModuleException("Exception");
     }
 

--- a/tests/DefectiveModule/lotgd.yml
+++ b/tests/DefectiveModule/lotgd.yml
@@ -1,3 +1,4 @@
 entityNamespace: "LotGD\\Core\\Tests\\FakeModule\\Models\\"
 subscriptionPatterns:
-    - "e/lotgd/core/tests/event"
+    - "e/lotgd/core/tests/defective-event"
+    - "e/lotgd/core/tests/gom-event"

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -96,6 +96,7 @@ class EventManagerTest extends CoreModelTestCase
         $library = 'lotgd/tests';
 
         $em->subscribe($pattern, $class, $library);
+        $this->getEntityManager()->flush();
 
         $sub = EventSubscription::create([
             'pattern' => $pattern,

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -128,7 +128,7 @@ class GameTest extends CoreModelTestCase
 
     public function testSetGetCharacter()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(1);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
 
         $this->g->setCharacter($c);
         $this->assertEquals($c, $this->g->getCharacter());
@@ -136,7 +136,7 @@ class GameTest extends CoreModelTestCase
 
     public function testGetViewpointException()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(1);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $this->g->setCharacter($c);
 
         // There should'nt be any listeners to provide a default scene.
@@ -146,7 +146,7 @@ class GameTest extends CoreModelTestCase
 
     public function testGetViewpointStored()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(2);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         $this->g->setCharacter($c);
 
         $this->assertNotNull($this->g->getViewpoint());
@@ -154,7 +154,7 @@ class GameTest extends CoreModelTestCase
 
     public function testGetViewpointDefault()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(1);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $this->g->setCharacter($c);
 
         $this->g->getEventManager()->subscribe('/h\/lotgd\/core\/default-scene/', DefaultSceneProvider::class, 'lotgd/core/tests');
@@ -176,7 +176,7 @@ class GameTest extends CoreModelTestCase
 
     public function testTakeActionNonExistant()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(1);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $this->g->setCharacter($c);
 
         // For now, I cant seem to serialize a proper ActionGroup to store in
@@ -189,7 +189,7 @@ class GameTest extends CoreModelTestCase
 
     public function testTakeActionNavigate()
     {
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(3);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000003");
         $this->g->setCharacter($c);
 
         // For now, I cant seem to serialize a proper ActionGroup to store in
@@ -210,7 +210,7 @@ class GameTest extends CoreModelTestCase
     public function testIfActionParametersAreRelayedToEvent()
     {
         /* @var $c Character */
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(2);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         $this->g->setCharacter($c);
 
         // subscribe event
@@ -240,7 +240,7 @@ class GameTest extends CoreModelTestCase
     public function testIfActionParametersTakePriorityToOtherParameters()
     {
         /* @var $c Character */
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(2);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         $this->g->setCharacter($c);
 
         // subscribe event
@@ -288,7 +288,7 @@ class GameTest extends CoreModelTestCase
             return $values;
         };
 
-        $c = $this->getEntityManager()->getRepository(Character::class)->find(3);
+        $c = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000003");
         $this->g->setCharacter($c);
 
         $v0 = $this->g->getViewpoint();

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -37,15 +37,16 @@ class DefaultSceneProvider implements EventHandler
                     ));
                 }
 
-                $context->setDataField("scene", $g->getEntityManager()->getRepository(Scene::class)->find(1));
+                $context->setDataField("scene", $g->getEntityManager()->getRepository(Scene::class)
+                    ->find("30000000-0000-0000-0000-000000000001"));
                 break;
             case 'h/lotgd/core/navigate-to/lotgd/tests/village':
                 $v = $context->getDataField('viewpoint');
 
                 self::$actionGroups = [new ActionGroup('default', 'Title', 0)];
                 self::$actionGroups[0]->setActions([
-                    new Action(2), // This is a real sceneId in game.yml
-                    new Action(101),
+                    new Action("30000000-0000-0000-0000-000000000002"), // This is a real sceneId in game.yml
+                    new Action("30000000-0000-0000-0000-000000000101"),
                 ]);
                 $v->setActionGroups(self::$actionGroups);
 
@@ -217,7 +218,7 @@ class GameTest extends CoreModelTestCase
         $this->g->getEventManager()->subscribe('#h/lotgd/core/navigate-to/lotgd/tests/paramaters#', DefaultSceneProvider::class, 'lotgd/core/tests');
         $this->getEntityManager()->flush();
 
-        $action = new Action(7, null, ["foo" => "baz"]);
+        $action = new Action("30000000-0000-0000-0000-000000000007", null, ["foo" => "baz"]);
         $actionId = $action->getId();
 
         $ag = new ActionGroup("group1", "Group 1", 5);
@@ -247,7 +248,7 @@ class GameTest extends CoreModelTestCase
         $this->g->getEventManager()->subscribe('#h/lotgd/core/navigate-to/lotgd/tests/paramaters#', DefaultSceneProvider::class, 'lotgd/core/tests');
         $this->getEntityManager()->flush();
 
-        $action = new Action(7, null, ["foo" => "baz"]);
+        $action = new Action("30000000-0000-0000-0000-000000000007", null, ["foo" => "baz"]);
         $actionId = $action->getId();
 
         $ag = new ActionGroup("group1", "Group 1", 5);
@@ -298,9 +299,9 @@ class GameTest extends CoreModelTestCase
         $this->assertSame([
             "Parent Scene",
             [
-                ActionGroup::DefaultGroup => [1],
-                "lotgd/tests/none/child1" => [5],
-                "lotgd/tests/none/child2" => [6],
+                ActionGroup::DefaultGroup => ["30000000-0000-0000-0000-000000000001"],
+                "lotgd/tests/none/child1" => ["30000000-0000-0000-0000-000000000005"],
+                "lotgd/tests/none/child2" => ["30000000-0000-0000-0000-000000000006"],
                 ActionGroup::HiddenGroup => [],
             ]
         ], $viewpointToArray($v1));
@@ -310,7 +311,10 @@ class GameTest extends CoreModelTestCase
         $this->assertSame([
             "Child Scene 1",
             [
-                ActionGroup::DefaultGroup => [6, 4],
+                ActionGroup::DefaultGroup => [
+                    "30000000-0000-0000-0000-000000000006",
+                    "30000000-0000-0000-0000-000000000004"
+                ],
                 ActionGroup::HiddenGroup => [],
             ]
         ], $viewpointToArray($v2));
@@ -320,7 +324,7 @@ class GameTest extends CoreModelTestCase
         $this->assertSame([
             "Child Scene 2",
             [
-                ActionGroup::DefaultGroup => [4],
+                ActionGroup::DefaultGroup => ["30000000-0000-0000-0000-000000000004"],
                 ActionGroup::HiddenGroup => [],
             ]
         ], $viewpointToArray($v3));

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -159,6 +159,7 @@ class GameTest extends CoreModelTestCase
 
         $this->g->getEventManager()->subscribe('/h\/lotgd\/core\/default-scene/', DefaultSceneProvider::class, 'lotgd/core/tests');
         $this->g->getEventManager()->subscribe('/h\/lotgd\/core\/navigate-to\/.*/', DefaultSceneProvider::class, 'lotgd/core/tests');
+        $this->getEntityManager()->flush();
 
         $v = $this->g->getViewpoint();
         // Run it twice to make sure no additional DB operations happen.
@@ -214,6 +215,7 @@ class GameTest extends CoreModelTestCase
 
         // subscribe event
         $this->g->getEventManager()->subscribe('#h/lotgd/core/navigate-to/lotgd/tests/paramaters#', DefaultSceneProvider::class, 'lotgd/core/tests');
+        $this->getEntityManager()->flush();
 
         $action = new Action(7, null, ["foo" => "baz"]);
         $actionId = $action->getId();
@@ -243,6 +245,7 @@ class GameTest extends CoreModelTestCase
 
         // subscribe event
         $this->g->getEventManager()->subscribe('#h/lotgd/core/navigate-to/lotgd/tests/paramaters#', DefaultSceneProvider::class, 'lotgd/core/tests');
+        $this->getEntityManager()->flush();
 
         $action = new Action(7, null, ["foo" => "baz"]);
         $actionId = $action->getId();

--- a/tests/ModelTestCase.php
+++ b/tests/ModelTestCase.php
@@ -63,6 +63,9 @@ abstract class ModelTestCase extends \PHPUnit_Extensions_Database_TestCase
 
                 self::$em = EntityManager::create(["pdo" => self::$pdo], $configuration);
 
+                // Register uuid type
+                \Doctrine\DBAL\Types\Type::addType('uuid', 'Ramsey\Uuid\Doctrine\UuidType');
+
                 // Create Schema
                 $metaData = self::$em->getMetadataFactory()->getAllMetadata();
                 $schemaTool = new SchemaTool(self::$em);

--- a/tests/Models/CharacterModelTest.php
+++ b/tests/Models/CharacterModelTest.php
@@ -12,6 +12,7 @@ use LotGD\Core\Models\Character;
 use LotGD\Core\Models\CharacterProperty;
 use LotGD\Core\Tests\CoreModelTestCase;
 use LotGD\Core\Models\Repositories\CharacterRepository;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Tests the management of Characters
@@ -26,13 +27,13 @@ class CharacterModelTest extends CoreModelTestCase
      */
     public function testSoftDeletion()
     {
-        $chars = $this->getEntityManager()->getRepository(Character::class)->find(3);
+        $chars = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000003");
         $this->assertSame(null, $chars);
 
         $allChars = $this->getEntityManager()->getRepository(Character::class)->findAll();
         $this->assertSame(2, count($allChars));
 
-        $char = $this->getEntityManager()->getRepository(Character::class)->find(1);
+        $char = $this->getEntityManager()->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $char->delete($this->getEntityManager());
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
@@ -101,7 +102,7 @@ class CharacterModelTest extends CoreModelTestCase
 
         $em->flush();
 
-        $this->assertInternalType("int", $characterEntity->getId());
+        $this->assertInstanceOf(UuidInterface::class, $characterEntity->getId());
         $this->assertSame(16, $characterEntity->getProperty("a property"));
 
         $em->flush();
@@ -142,7 +143,7 @@ class CharacterModelTest extends CoreModelTestCase
         $rowsBefore = count($em->getRepository(Character::class)->findAll());
 
         // Delete one row
-        $character = $em->getRepository(Character::class)->find(1);
+        $character = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $character->delete($em);
 
         $em->clear();
@@ -163,7 +164,7 @@ class CharacterModelTest extends CoreModelTestCase
         $em = $this->getEntityManager();
 
         // test default values
-        $firstCharacter = $em->getRepository(Character::class)->find(1);
+        $firstCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         $this->assertSame(5, $firstCharacter->getProperty("dragonkills", 5));
         $this->assertNotSame(5, $firstCharacter->getProperty("dragonkills", "5"));
         $this->assertSame("hanniball", $firstCharacter->getProperty("petname", "hanniball"));
@@ -226,6 +227,7 @@ class CharacterModelTest extends CoreModelTestCase
 
         $eventManager->subscribe("#h/lotgd/core/getCharacterAttack#", get_class($detectionClass), "test");
         $eventManager->subscribe("#h/lotgd/core/getCharacterDefense#", get_class($detectionClass), "test");
+        $this->getEntityManager()->flush();
 
         $this->assertSame($level*2, $character1->getAttack());
         $this->assertSame($level*4, $character2->getDefense());

--- a/tests/Models/MessageModelTest.php
+++ b/tests/Models/MessageModelTest.php
@@ -64,7 +64,7 @@ class MessageModelTest extends CoreModelTestCase
 
         $character1 = $em->getRepository(Character::class)->find(1);
         $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->find(3, NULL, NULL, CharacterRepository::INCLUDE_SOFTDELETED);
+        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted(3);
         $character4 = $em->getRepository(Character::class)->find(4);
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);
@@ -92,7 +92,7 @@ class MessageModelTest extends CoreModelTestCase
         
         $character1 = $em->getRepository(Character::class)->find(1);
         $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->find(3, NULL, NULL, CharacterRepository::INCLUDE_SOFTDELETED);
+        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted(3);
         $character4 = $em->getRepository(Character::class)->find(4);
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);

--- a/tests/Models/MessageModelTest.php
+++ b/tests/Models/MessageModelTest.php
@@ -24,8 +24,8 @@ class MessageModelTest extends CoreModelTestCase
         $em = $this->getEntityManager();
         $mm=new MessageManager();
 
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(4);
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000004");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2]);
         $thread2 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character2, $character1]);
@@ -42,8 +42,8 @@ class MessageModelTest extends CoreModelTestCase
         $em->flush();
         $em->clear();
         
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(4);
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000004");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2]);
         
@@ -62,10 +62,10 @@ class MessageModelTest extends CoreModelTestCase
         $em = $this->getEntityManager();
         $mm=new MessageManager();
 
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted(3);
-        $character4 = $em->getRepository(Character::class)->find(4);
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
+        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted("10000000-0000-0000-0000-000000000003");
+        $character4 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000004");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);
         $thread2 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character4, $character2, $character1, $character3]);
@@ -89,11 +89,11 @@ class MessageModelTest extends CoreModelTestCase
         $this->assertSame(1, count($character4->getMessageThreads()));
         
         $em->flush();
-        
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
-        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted(3);
-        $character4 = $em->getRepository(Character::class)->find(4);
+
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
+        $character3 = $em->getRepository(Character::class)->findWithSoftDeleted("10000000-0000-0000-0000-000000000003");
+        $character4 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000004");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2, $character3, $character4]);
         
@@ -111,8 +111,8 @@ class MessageModelTest extends CoreModelTestCase
         $em = $this->getEntityManager();
         $mm=new MessageManager();
 
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character1]);
         $thread2 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character2]);
@@ -124,9 +124,9 @@ class MessageModelTest extends CoreModelTestCase
         
         $em->flush();
         $em->clear();
-        
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
+
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character1]);
         $thread2 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character2]);
@@ -154,8 +154,8 @@ class MessageModelTest extends CoreModelTestCase
         $em = $this->getEntityManager();
         $mm=new MessageManager();
 
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character1, $character2]);
         $thread2 = $em->getRepository(MessageThread::class)->findOrCreateFor([$character1, $character2]);
@@ -166,9 +166,9 @@ class MessageModelTest extends CoreModelTestCase
         
         $em->flush();
         $em->clear();
-        
-        $character1 = $em->getRepository(Character::class)->find(1);
-        $character2 = $em->getRepository(Character::class)->find(2);
+
+        $character1 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $character2 = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         
         $thread1 = $em->getRepository(MessageThread::class)->findOrCreateReadonlyFor([$character1, $character2]);
         

--- a/tests/Models/MotdModelTest.php
+++ b/tests/Models/MotdModelTest.php
@@ -19,7 +19,7 @@ class MotDModelTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
         
-        $author = $em->getRepository(Character::class)->find(1);
+        $author = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         
         // Test normal message
         $motd1 = $em->getRepository(MotD::class)->find(1);
@@ -63,13 +63,13 @@ class MotDModelTest extends CoreModelTestCase
     {
         return [
             [[
-                "author" => 1,
+                "author" => "10000000-0000-0000-0000-000000000001",
                 "title" => "ABC_\"EFG",
                 "body" => "Lorem îpsum etc pp",
                 "systemMessage" => false,
             ]],
             [[
-                "author" => 1,
+                "author" => "10000000-0000-0000-0000-000000000001",
                 "title" => "AnotherOne",
                 "body" => "Test a Second One",
                 "systemMessage" => true,

--- a/tests/Models/MotdModelTest.php
+++ b/tests/Models/MotdModelTest.php
@@ -22,7 +22,7 @@ class MotDModelTest extends CoreModelTestCase
         $author = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
         
         // Test normal message
-        $motd1 = $em->getRepository(MotD::class)->find(1);
+        $motd1 = $em->getRepository(MotD::class)->find("20000000-0000-0000-0000-000000000001");
         $this->assertSame("This is the title", $motd1->getTitle());
         $this->assertSame("This is the body of the message", $motd1->getBody());
         $this->assertSame($author, $motd1->getAuthor());
@@ -30,14 +30,14 @@ class MotDModelTest extends CoreModelTestCase
         $this->assertFalse($motd1->getSystemMessage());
         
         // Test System message
-        $motd2 = $em->getRepository(MotD::class)->find(2);
+        $motd2 = $em->getRepository(MotD::class)->find("20000000-0000-0000-0000-000000000002");
         $this->assertTrue($motd2->getSystemMessage());
         $this->assertNotSame($motd2->getAuthor(), $motd2->getApparantAuthor());
         $this->assertSame($author, $motd2->getAuthor());
         $this->assertNotSame("Deleted Character Name", $motd2->getAuthor()->getDisplayName());
         
         // Test message with unknown author
-        $motd3 = $em->getRepository(Motd::class)->find(3);
+        $motd3 = $em->getRepository(Motd::class)->find("20000000-0000-0000-0000-000000000003");
         $this->assertSame("Deleted Testcharacter", $motd3->getAuthor()->getDisplayName());
     }
     
@@ -45,7 +45,7 @@ class MotDModelTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
         
-        $time1 = $em->getRepository(MotD::class)->find(1)->getCreationTime();
+        $time1 = $em->getRepository(MotD::class)->find("20000000-0000-0000-0000-000000000001")->getCreationTime();
         $time2 = new \DateTime("2016-05-03 14:19:12");
         $time3 = $time2->setTimezone(new \DateTimeZone("Europe/Zurich"));
         $time4 = new \DateTime("2016-05-03 14:19:12");
@@ -87,10 +87,9 @@ class MotDModelTest extends CoreModelTestCase
         $motdCreationArguments["author"] = $em->getRepository(Character::class)->find($motdCreationArguments["author"]);
         
         $motd = MotD::create($motdCreationArguments);
-        $motd->save($em);
-        
         $id = $motd->getId();
-        
+
+        $em->persist($motd);
         $em->flush();
         $em->clear();
         

--- a/tests/Models/SceneModelTest.php
+++ b/tests/Models/SceneModelTest.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Tests\Models;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Models\{Scene, SceneConnection, SceneConnectionGroup};
 use LotGD\Core\Tests\CoreModelTestCase;
@@ -54,6 +52,8 @@ class SceneModelTest extends CoreModelTestCase
 
         // create new scene, flush and clear. Number of scenes in db should be +1
         $newScene = Scene::create($this->getTestSceneData());
+        $id = $newScene->getId();
+
         $newScene->save($em);
         $this->flushAndClear();
         unset($newScene);
@@ -63,7 +63,7 @@ class SceneModelTest extends CoreModelTestCase
         $this->assertSame($n1 + 1, $n2);
 
         // fetch new scene, delete, flush and clear.
-        $newScene = $em->getRepository(Scene::class)->findOneBy($this->getTestSceneData());
+        $newScene = $em->getRepository(Scene::class)->find($id);
         $newScene->delete($em);
         $this->flushAndClear();
 
@@ -87,7 +87,7 @@ class SceneModelTest extends CoreModelTestCase
         // create new scene, connect to another one. Number of scenes must be +1, number of connections must be +1
         // this tests for cascade=persist
         $scene = Scene::create($this->getTestSceneData());
-        $scene->connect($em->getRepository(Scene::class)->find(1));
+        $scene->connect($em->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001"));
         $scene->save($em);
         $this->flushAndClear();
         unset($scene);
@@ -144,7 +144,7 @@ class SceneModelTest extends CoreModelTestCase
     public function testGetters()
     {
         $em = $this->getEntityManager();
-        $scene = $em->getRepository(Scene::class)->find(2);
+        $scene = $em->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
 
         $this->assertEquals("The Forest", $scene->getTitle());
         $this->assertEquals("This is a very dangerous and dark forest", $scene->getDescription());
@@ -154,7 +154,7 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfHasConnectionGroupReturnsTrueIfConnectionGroupExists()
     {
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(1);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find( "30000000-0000-0000-0000-000000000001");
 
         $this->assertTrue($scene->hasConnectionGroup("lotgd/tests/village/outside"));
         $this->assertTrue($scene->hasConnectionGroup("lotgd/tests/village/market"));
@@ -163,14 +163,14 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfHasConnectionGroupReturnsFalseIfConnectionGroupDoesNotExist()
     {
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(2);
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find( "30000000-0000-0000-0000-000000000002");
 
         $this->assertFalse($scene2->hasConnectionGroup("lotgd/tests/village/outside"));
         $this->assertFalse($scene2->hasConnectionGroup("lotgd/tests/village/market"));
         $this->assertFalse($scene2->hasConnectionGroup("lotgd/tests/village/empty"));
 
 
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
 
         $this->assertFalse($scene1->hasConnectionGroup("lotgd/tests/village/23426"));
     }
@@ -178,7 +178,7 @@ class SceneModelTest extends CoreModelTestCase
     public function testIfAddConnectionGroupWorks()
     {
         $connectionGroup = new SceneConnectionGroup("lotgd/tests/village/new", "New Street");
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(1);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
 
         $this->assertFalse($scene->hasConnectionGroup("lotgd/tests/village/new"));
 
@@ -191,8 +191,9 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfAddConnectionGroupThrowsArgumentExceptionIfGroupIsAlreadyAssignedToItself()
     {
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)->findOneBy(["scene" => 1, "name" => "lotgd/tests/village/outside"]);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)
+            ->findOneBy(["scene" => "30000000-0000-0000-0000-000000000001", "name" => "lotgd/tests/village/outside"]);
 
         $this->expectException(ArgumentException::class);
         $scene->addConnectionGroup($connectionGroup);
@@ -200,8 +201,9 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfAddConnectionGroupThrowsArgumentExceptionIfGroupIsAlreadyAssignedToSomwhereElse()
     {
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(2);
-        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)->findOneBy(["scene" => 1, "name" => "lotgd/tests/village/outside"]);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
+        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)
+            ->findOneBy(["scene" => "30000000-0000-0000-0000-000000000001", "name" => "lotgd/tests/village/outside"]);
 
         $this->expectException(ArgumentException::class);
         $scene->addConnectionGroup($connectionGroup);
@@ -209,8 +211,9 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testifDropConnectionGroupWorks()
     {
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)->findOneBy(["scene" => 1, "name" => "lotgd/tests/village/outside"]);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)
+            ->findOneBy(["scene" => "30000000-0000-0000-0000-000000000001", "name" => "lotgd/tests/village/outside"]);
 
         $this->assertTrue($scene->hasConnectionGroup("lotgd/tests/village/outside"));
 
@@ -223,8 +226,9 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfDropConnectionGroupThrowsArgumentExceptionIfEntityIsRemovedFromNonOwningScene()
     {
-        $scene = $this->getEntityManager()->getRepository(Scene::class)->find(2);
-        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)->findOneBy(["scene" => 1, "name" => "lotgd/tests/village/outside"]);
+        $scene = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
+        $connectionGroup = $this->getEntityManager()->getRepository(SceneConnectionGroup::class)
+            ->findOneBy(["scene" => "30000000-0000-0000-0000-000000000001", "name" => "lotgd/tests/village/outside"]);
 
         $this->expectException(ArgumentException::class);
         $scene->dropConnectionGroup($connectionGroup);
@@ -232,8 +236,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfGetConnectedScenesReturnsConnectedScenes()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(2);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
 
         $this->assertCount(3, $scene1->getConnectedScenes());
         $this->assertCount(1, $scene2->getConnectedScenes());
@@ -246,9 +250,9 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfIsConnectedToReturnsExpectedReturnValue()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(2);
-        $scene5 = $this->getEntityManager()->getRepository(Scene::class)->find(5);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
+        $scene5 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000005");
 
         $this->assertTrue($scene1->isConnectedTo($scene2));
         $this->assertTrue($scene2->isConnectedTo($scene1));
@@ -260,8 +264,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfTwoScenesCanGetConnected()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(2);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(5);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000005");
 
         $scene1->connect($scene2);
 
@@ -275,8 +279,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfASceneConnectionGroupCanGetConnectedToAScene()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(5);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000005");
 
         $scene1->getConnectionGroup("lotgd/tests/village/outside")->connect($scene2);
 
@@ -290,8 +294,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfASceneCanGetConnectedToASceneConnectionGroup()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(5);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000005");
 
         $scene2->connect($scene1->getConnectionGroup("lotgd/tests/village/outside"));
 
@@ -305,8 +309,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfASceneConnectionGroupCanGetConnectedToAnotherSceneConnectionGroup()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(5);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000005");
         $scene2->addConnectionGroup(new SceneConnectionGroup("test/orphaned", "Orphan group"));
 
         $scene1
@@ -325,7 +329,7 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfConnectingASceneToItselfThrowsAnException()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
 
         $this->expectException(ArgumentException::class);
         $scene1->connect($scene1);
@@ -344,8 +348,8 @@ class SceneModelTest extends CoreModelTestCase
 
     public function testIfConnectingASceneToAnotherAlreadyConnectedSceneThrowsAnException()
     {
-        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find(1);
-        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find(2);
+        $scene1 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000001");
+        $scene2 = $this->getEntityManager()->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
 
         $this->expectException(ArgumentException::class);
         $scene1->connect($scene2);

--- a/tests/Models/ViewpointTest.php
+++ b/tests/Models/ViewpointTest.php
@@ -40,8 +40,8 @@ class ViewpointTest extends CoreModelTestCase
         $em = $this->getEntityManager();
 
         // Test character with a characterScene
-        $testCharacter = $em->getRepository(Character::class)->find(2);
-        $this->assertSame(2, $testCharacter->getId());
+        $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
+        $this->assertSame("10000000-0000-0000-0000-000000000002", (string)$testCharacter->getId());
         $characterScene = $testCharacter->getViewpoint();
 
         $this->assertInstanceOf(Viewpoint::class, $characterScene);
@@ -49,8 +49,8 @@ class ViewpointTest extends CoreModelTestCase
         $this->assertSame("This is the village.", $characterScene->getDescription());
 
         // Test character without a characterScene
-        $testCharacter = $em->getRepository(Character::class)->find(1);
-        $this->assertSame(1, $testCharacter->getId());
+        $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000001");
+        $this->assertSame("10000000-0000-0000-0000-000000000001", (string)$testCharacter->getId());
         $characterScene = $testCharacter->getViewpoint();
 
         $this->assertNull($characterScene);
@@ -63,7 +63,7 @@ class ViewpointTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $testCharacter = $em->getRepository(Character::class)->find(2);
+        $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
 
         $testScene = $em->getRepository(Scene::class)->find(2);
 
@@ -95,13 +95,13 @@ class ViewpointTest extends CoreModelTestCase
             $ag2
         ];
 
-        $input = $em->getRepository(Viewpoint::class)->find(2);
+        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $input->setActionGroups($actionGroups);
         $input->save($em);
 
         $em->clear();
 
-        $output = $em->getRepository(Viewpoint::class)->find(2);
+        $output = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $this->assertEquals($actionGroups, $output->getActionGroups());
 
         $this->assertEquals($ag2, $input->findActionGroupById('id2'));
@@ -124,13 +124,13 @@ class ViewpointTest extends CoreModelTestCase
 
         $attachments = [$a1, $a2];
 
-        $input = $em->getRepository(Viewpoint::class)->find(2);
+        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $input->setAttachments($attachments);
         $input->save($em);
 
         $em->clear();
 
-        $output = $em->getRepository(Viewpoint::class)->find(2);
+        $output = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $this->assertEquals($attachments, $output->getAttachments());
         $this->assertEquals('baz', $output->getAttachments()[0]->getFoo());
         $this->assertEquals('fiz', $output->getAttachments()[1]->getFoo());
@@ -160,13 +160,13 @@ class ViewpointTest extends CoreModelTestCase
             $ag2
         ];
 
-        $input = $em->getRepository(Viewpoint::class)->find(2);
+        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $input->setActionGroups($actionGroups);
         $input->save($em);
 
         $em->clear();
 
-        $output = $em->getRepository(Viewpoint::class)->find(2);
+        $output = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
 
         // Not finding the scene ID should change nothing.
         $output->removeActionsWithSceneId(1000);
@@ -189,7 +189,7 @@ class ViewpointTest extends CoreModelTestCase
     public function testChangingSceneDescription()
     {
         $em = $this->getEntityManager();
-        $testCharacter = $em->getRepository(Character::class)->find(2);
+        $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         $characterScene = $testCharacter->getViewpoint();
 
         $this->assertSame("This is the village.", $characterScene->getDescription());
@@ -201,7 +201,7 @@ class ViewpointTest extends CoreModelTestCase
     public function testClearingSceneDescription()
     {
         $em = $this->getEntityManager();
-        $testCharacter = $em->getRepository(Character::class)->find(2);
+        $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
         $characterScene = $testCharacter->getViewpoint();
 
         $characterScene->clearDescription();
@@ -235,14 +235,14 @@ class ViewpointTest extends CoreModelTestCase
             $ag2
         ];
 
-        $input = $em->getRepository(Viewpoint::class)->find(2);
+        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
         $input->setActionGroups($actionGroups);
         $input->save($em);
 
         $em->clear();
 
         /** @var Viewpoint $viewpoint */
-        $viewpoint = $em->getRepository(Viewpoint::class)->find(2);
+        $viewpoint = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
 
         $actionGroupId1 = $viewpoint->findActionGroupById("id1");
         $actionGroupId2 = $viewpoint->findActionGroupById("id2");

--- a/tests/Models/ViewpointTest.php
+++ b/tests/Models/ViewpointTest.php
@@ -65,7 +65,7 @@ class ViewpointTest extends CoreModelTestCase
 
         $testCharacter = $em->getRepository(Character::class)->find("10000000-0000-0000-0000-000000000002");
 
-        $testScene = $em->getRepository(Scene::class)->find(2);
+        $testScene = $em->getRepository(Scene::class)->find("30000000-0000-0000-0000-000000000002");
 
         $this->assertSame("The Village", $testCharacter->getViewpoint()->getTitle());
 
@@ -82,12 +82,12 @@ class ViewpointTest extends CoreModelTestCase
 
         $ag1 = new ActionGroup('id1', 'title1', 42);
         $ag1->setActions([
-            new Action(1),
-            new Action(2)
+            new Action("30000000-0000-0000-0000-000000000001"),
+            new Action("30000000-0000-0000-0000-000000000002")
         ]);
         $ag2 = new ActionGroup('id2', 'title2', 101);
         $ag2->setActions([
-            new Action(3)
+            new Action("30000000-0000-0000-0000-000000000003")
         ]);
 
         $actionGroups = [
@@ -107,7 +107,7 @@ class ViewpointTest extends CoreModelTestCase
         $this->assertEquals($ag2, $input->findActionGroupById('id2'));
         $this->assertNull($input->findActionGroupById('not-there'));
 
-        $testAction = new Action(4);
+        $testAction = new Action("30000000-0000-0000-0000-000000000004");
         $input->addActionToGroupId($testAction, 'not-there');
         $this->assertNull($input->findActionById($testAction->getId()));
 
@@ -140,9 +140,9 @@ class ViewpointTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $a1 = new Action(1);
-        $a2 = new Action(2);
-        $a3 = new Action(3);
+        $a1 = new Action("30000000-0000-0000-0000-000000000001");
+        $a2 = new Action("30000000-0000-0000-0000-000000000002");
+        $a3 = new Action("30000000-0000-0000-0000-000000000003");
 
         $ag1 = new ActionGroup('id1', 'title1', 42);
         $ag1->setActions([
@@ -152,7 +152,7 @@ class ViewpointTest extends CoreModelTestCase
         ]);
         $ag2 = new ActionGroup('id2', 'title2', 101);
         $ag2->setActions([
-            new Action(4)
+            new Action("30000000-0000-0000-0000-000000000004")
         ]);
 
         $actionGroups = [
@@ -169,7 +169,7 @@ class ViewpointTest extends CoreModelTestCase
         $output = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
 
         // Not finding the scene ID should change nothing.
-        $output->removeActionsWithSceneId(1000);
+        $output->removeActionsWithSceneId("30000000-0000-0000-0000-000000001000");
         $this->assertEquals($actionGroups, $output->getActionGroups());
 
         $ag1_output = new ActionGroup('id1', 'title1', 42);
@@ -182,7 +182,7 @@ class ViewpointTest extends CoreModelTestCase
             $ag1_output,
             $ag2
         ];
-        $output->removeActionsWithSceneId(2);
+        $output->removeActionsWithSceneId("30000000-0000-0000-0000-000000000002");
         $this->assertEquals($actionGroupsWithout2, $output->getActionGroups());
     }
 
@@ -215,9 +215,9 @@ class ViewpointTest extends CoreModelTestCase
     {
         $em = $this->getEntityManager();
 
-        $a1 = new Action(1);
-        $a2 = new Action(2);
-        $a3 = new Action(3);
+        $a1 = new Action("30000000-0000-0000-0000-000000000001");
+        $a2 = new Action("30000000-0000-0000-0000-000000000002");
+        $a3 = new Action("30000000-0000-0000-0000-000000000003");
 
         $ag1 = new ActionGroup('id1', 'title1', 42);
         $ag1->setActions([
@@ -227,7 +227,7 @@ class ViewpointTest extends CoreModelTestCase
         ]);
         $ag2 = new ActionGroup('id2', 'title2', 101);
         $ag2->setActions([
-            new Action(4)
+            new Action("30000000-0000-0000-0000-000000000004")
         ]);
 
         $actionGroups = [

--- a/tests/datasets/battle.yml
+++ b/tests/datasets/battle.yml
@@ -1,48 +1,48 @@
 characters:
     -
-        id: 1
+        id: "d363c077-234a-433d-834e-f1a1d3b281d8"
         name: "Player"
         displayName: "The Player"
         health: 100
         maxhealth: 100
         level: 10
     -
-        id: 2
+        id: "4d01c29b-d825-4bc7-9e6e-63525155fd37"
         name: "High Level Char"
         displayName: "High Level Char"
         health: 1000
         maxhealth: 1000
         level: 100
     -
-        id: 3
+        id: "c3792b61-4e34-4710-9871-65a68ac30bb4"
         name: "Low Level Char"
         displayName: "Low Level Char"
         health: 10
         maxhealth: 10
         level: 1
     -
-        id: 4
+        id: "6565b418-55f5-4a6b-8d92-a9ef81329912"
         name: "Low Damage Char"
         displayName: "Low Damage Char"
         health: 500
         maxhealth: 500
         level: 0
     -
-        id: 10
+        id: "539e4bb0-84d1-49ed-a697-ff449991e9b7"
         name: "Level 10 Character"
         displayName: "Level 10 Character"
         health: 100
         maxhealth: 100
         level: 10
     -
-        id: 11
+        id: "24d71c26-f915-401c-8b3e-1932edf650ce"
         name: "Level 11 Character"
         displayName: "Level 11 Character"
         health: 110
         maxhealth: 110
         level: 11
     -
-        id: 13
+        id: "1a9f63f2-3006-4e12-b272-4fd6be518a93"
         name: "Level 13 Character"
         displayName: "Level 13 Character"
         health: 130
@@ -50,26 +50,26 @@ characters:
         level: 13
 monsters:
     -
-        id: 1
+        id: "de84c507-9673-44e7-b665-9e43416b9c2f"
         name: "Evil Monster"
         level: 5
     -
-        id: 2
+        id: "b636df29-f72d-4e2d-9850-982e783a9e94"
         name: "High Dragon"
         level: 100
     -
-        id: 3
+        id: "c004bcb6-a7c1-4f9a-abc2-1711c64e23a0"
         name: "Stone"
         level: 1
     -
-        id: 10
+        id: "f1d1f672-e308-420e-939f-cbb39285b222"
         name: "Level 10 Monster"
         level: 10
     -
-        id: 11
+        id: "7ca9c141-aaf8-44a5-9d04-b6f9923f3c66"
         name: "Level 11 Monster"
         level: 11
     -
-        id: 13
+        id: "09540b93-63c9-4d82-8501-f569f63dfc4c"
         name: "Level 13 Monster"
         level: 13

--- a/tests/datasets/character.yml
+++ b/tests/datasets/character.yml
@@ -1,18 +1,18 @@
 characters:
     -
-        id: 1
+        id: "10000000-0000-0000-0000-000000000001"
         name: "Testcharacter 1"
         displayName: "Testcharacter 1"
         health: 0
         maxhealth: 100
     -
-        id: 2
+        id: "10000000-0000-0000-0000-000000000002"
         name: "Testcharacter 2"
         displayName: "Testcharacter 2"
         health: 90
         maxhealth: 90
     -
-        id: 3
+        id: "10000000-0000-0000-0000-000000000003"
         name: "Testcharacter 3"
         displayName: "Testcharacter 3 (deleted)"
         health: 90
@@ -20,6 +20,6 @@ characters:
         deletedAt: "2011-11-11 11:11:11"
 character_properties:
     -
-        owner_id: 1
+        owner_id: "10000000-0000-0000-0000-000000000001"
         propertyName: "test"
         propertyValue: 's:5:"hallo";'

--- a/tests/datasets/game.yml
+++ b/tests/datasets/game.yml
@@ -22,74 +22,74 @@ viewpoints:
         actionGroups: "a:0:{}"
 scenes:
     -
-        id: 1
+        id: "30000000-0000-0000-0000-000000000001"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"
     -
-        id: 2
+        id: "30000000-0000-0000-0000-000000000002"
         title: "The Forest"
         description: "This is a very dangerous and dark forest"
         template: "lotgd/tests/forest"
     -
-        id: 3
+        id: "30000000-0000-0000-0000-000000000003"
         title: "The Weaponry"
         description: "This is the place where you can buy awesome weapons"
         template: "lotgd/tests/weaponry"
     -
-        id: 4
+        id: "30000000-0000-0000-0000-000000000004"
         title: "Parent Scene"
         description: "This is a parent scene that connects to two children."
         template: "lotgd/tests/none"
     -
-        id: 5
+        id: "30000000-0000-0000-0000-000000000005"
         title: "Child Scene 1"
         description: "This is a parent scene that connects to two children."
         template: "lotgd/tests/none"
     -
-        id: 6
+        id: "30000000-0000-0000-0000-000000000006"
         title: "Child Scene 2"
         description: "This is a parent scene that connects to two children."
         template: "lotgd/tests/none"
     -
-        id: 7
+        id: "30000000-0000-0000-0000-000000000007"
         title: "Parameter test"
         description: "This is a parameter test"
         template: "lotgd/tests/paramaters"
 scene_connection_groups:
     -
-        scene: 4
+        scene: "30000000-0000-0000-0000-000000000004"
         name: "lotgd/tests/none/child1"
         title: "Child 1"
     -
-        scene: 4
+        scene: "30000000-0000-0000-0000-000000000004"
         name: "lotgd/tests/none/child2"
         title: "Child 2"
 scene_connections:
     -
-        outgoingScene: 1
-        incomingScene: 2
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000002"
         directionality: 0
     -
-        outgoingScene: 1
-        incomingScene: 3
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000003"
         directionality: 0
     -
-        outgoingScene: 1
-        incomingScene: 4
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000004"
         directionality: 0
     -
-        outgoingScene: 4
-        incomingScene: 5
+        outgoingScene: "30000000-0000-0000-0000-000000000004"
+        incomingScene: "30000000-0000-0000-0000-000000000005"
         outgoingConnectionGroupName: "lotgd/tests/none/child1"
         directionality: 0
     -
-        outgoingScene: 4
-        incomingScene: 6
+        outgoingScene: "30000000-0000-0000-0000-000000000004"
+        incomingScene: "30000000-0000-0000-0000-000000000006"
         outgoingConnectionGroupName: "lotgd/tests/none/child2"
         directionality: 0
     -
-        outgoingScene: 5
-        incomingScene: 6
+        outgoingScene: "30000000-0000-0000-0000-000000000005"
+        incomingScene: "30000000-0000-0000-0000-000000000006"
         directionality: 1
 

--- a/tests/datasets/game.yml
+++ b/tests/datasets/game.yml
@@ -1,19 +1,19 @@
 characters:
     -
-        id: 1
+        id: "10000000-0000-0000-0000-000000000001"
         name: "Char without a Scene"
         displayName: "A"
     -
-        id: 2
+        id: "10000000-0000-0000-0000-000000000002"
         name: "Char with a Scene"
         displayName: "B"
     -
-        id: 3
+        id: "10000000-0000-0000-0000-000000000003"
         name: "Char without a Scene"
         displayName: "C"
 viewpoints:
     -
-        owner_id: 2
+        owner_id: "10000000-0000-0000-0000-000000000002"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"

--- a/tests/datasets/messages.yml
+++ b/tests/datasets/messages.yml
@@ -1,19 +1,19 @@
 characters:
     -
-        id: 1
+        id: "10000000-0000-0000-0000-000000000001"
         name: "Testcharacter 1"
         displayName: "Testcharacter 1"
     -
-        id: 2
+        id: "10000000-0000-0000-0000-000000000002"
         name: "Testcharacter 2"
         displayName: "Testcharacter 2"
     -
-        id: 3
+        id: "10000000-0000-0000-0000-000000000003"
         name: "Testcharacter 1"
         displayName: "Deleted Testcharacter"
         deletedAt: "2011-11-11 11:11:11"
     -
-        id: 4
+        id: "10000000-0000-0000-0000-000000000004"
         name: "Testcharacter 3"
         displayName: "Testcharacter 3"
 message_threads:
@@ -23,7 +23,7 @@ message_threads:
 messages:
     -
         id: 1
-        author_id: 1
+        author_id: "10000000-0000-0000-0000-000000000001"
         thread_id: 1
         message: "Hi!"
         createdAt: "2000-01-01 00:00:01"
@@ -31,7 +31,7 @@ messages:
 message_threads_x_characters:
     -
         messagethread_id: 1
-        character_id: 1
+        character_id: "10000000-0000-0000-0000-000000000001"
     -
         messagethread_id: 1
-        character_id: 2
+        character_id: "10000000-0000-0000-0000-000000000002"

--- a/tests/datasets/motd.yml
+++ b/tests/datasets/motd.yml
@@ -1,18 +1,18 @@
 characters:
     -
-        id: 1
+        id: "10000000-0000-0000-0000-000000000001"
         name: "Testcharacter 1"
         displayName: "Testcharacter 1"
         health: 0
         maxhealth: 100
     -
-        id: 2
+        id: "10000000-0000-0000-0000-000000000002"
         name: "Testcharacter 2"
         displayName: "Testcharacter 2"
         health: 90
         maxhealth: 90
     -
-        id: 3
+        id: "10000000-0000-0000-0000-000000000003"
         name: "Testcharacter 1"
         displayName: "Deleted Testcharacter"
         health: 200
@@ -21,21 +21,21 @@ characters:
 motd:
     -
         id: 1
-        author_id: 1
+        author_id: "10000000-0000-0000-0000-000000000001"
         title: "This is the title"
         body: "This is the body of the message"
         creationTime: "2016-05-03 14:19:12"
         systemMessage: false
     -
         id: 2
-        author_id: 1
+        author_id: "10000000-0000-0000-0000-000000000001"
         title: "This is a system message"
         body: "This is the body of the system message"
         creationTime: "2016-05-04 14:19:12"
         systemMessage: true
     -
         id: 3
-        author_id: 3
+        author_id: "10000000-0000-0000-0000-000000000003"
         title: "This is an old message."
         body: "This is an old message."
         creationTime: "2002-12-09 15:13:59"

--- a/tests/datasets/motd.yml
+++ b/tests/datasets/motd.yml
@@ -20,21 +20,21 @@ characters:
         deletedAt: "2011-11-11 11:11:11"
 motd:
     -
-        id: 1
+        id: "20000000-0000-0000-0000-000000000001"
         author_id: "10000000-0000-0000-0000-000000000001"
         title: "This is the title"
         body: "This is the body of the message"
         creationTime: "2016-05-03 14:19:12"
         systemMessage: false
     -
-        id: 2
+        id: "20000000-0000-0000-0000-000000000002"
         author_id: "10000000-0000-0000-0000-000000000001"
         title: "This is a system message"
         body: "This is the body of the system message"
         creationTime: "2016-05-04 14:19:12"
         systemMessage: true
     -
-        id: 3
+        id: "20000000-0000-0000-0000-000000000003"
         author_id: "10000000-0000-0000-0000-000000000003"
         title: "This is an old message."
         body: "This is an old message."

--- a/tests/datasets/scene.yml
+++ b/tests/datasets/scene.yml
@@ -1,53 +1,53 @@
 scenes:
     -
-        id: 1
+        id: "30000000-0000-0000-0000-000000000001"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"
     -
-        id: 2
+        id: "30000000-0000-0000-0000-000000000002"
         title: "The Forest"
         description: "This is a very dangerous and dark forest"
         template: "lotgd/tests/forest"
     -
-        id: 3
+        id: "30000000-0000-0000-0000-000000000003"
         title: "The Weaponry"
         description: "This is the place where you can buy awesome weapons"
         template: "lotgd/tests/weaponry"
     -
-        id: 4
+        id: "30000000-0000-0000-0000-000000000004"
         title: "Another Village"
         description: "This is another village"
         template: "lotgd/tests/village"
     -
-        id: 5
+        id: "30000000-0000-0000-0000-000000000005"
         title: "Orphan"
         description: "This is an orphan scene"
         template: "lotgd/tests/orphan"
 scene_connection_groups:
     -
-        scene: 1
+        scene: "30000000-0000-0000-0000-000000000001"
         name: "lotgd/tests/village/outside"
         title: "Outside"
     -
-        scene: 1
+        scene: "30000000-0000-0000-0000-000000000001"
         name: "lotgd/tests/village/market"
         title: "Market"
     -
-        scene: 1
+        scene: "30000000-0000-0000-0000-000000000001"
         name: "lotgd/tests/village/empty"
         title: "Empty"
     -
-        scene: 2
+        scene: "30000000-0000-0000-0000-000000000002"
         name: "lotgd/tests/forest/category"
         title: "Empty"
 scene_connections:
     -
-        outgoingScene: 1
-        incomingScene: 2
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000002"
     -
-        outgoingScene: 1
-        incomingScene: 3
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000003"
     -
-        outgoingScene: 1
-        incomingScene: 4
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000004"

--- a/tests/datasets/viewpoints.yml
+++ b/tests/datasets/viewpoints.yml
@@ -18,24 +18,24 @@ viewpoints:
         actionGroups: "a:0:{}"
 scenes:
     -
-        id: 1
+        id: "30000000-0000-0000-0000-000000000001"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"
     -
-        id: 2
+        id: "30000000-0000-0000-0000-000000000002"
         title: "The Forest"
         description: "This is a very dangerous and dark forest"
         template: "lotgd/tests/forest"
     -
-        id: 3
+        id: "30000000-0000-0000-0000-000000000003"
         title: "The Weaponry"
         description: "This is the place where you can buy awesome weapons"
         template: "lotgd/tests/weaponry"
 scene_connections:
     -
-        outgoingScene: 1
-        incomingScene: 2
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000002"
     -
-        outgoingScene: 1
-        incomingScene: 3
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000003"

--- a/tests/datasets/viewpoints.yml
+++ b/tests/datasets/viewpoints.yml
@@ -1,15 +1,15 @@
 characters:
     -
-        id: 1
+        id: "10000000-0000-0000-0000-000000000001"
         name: "Char without a Scene"
         displayName: "A"
     -
-        id: 2
+        id: "10000000-0000-0000-0000-000000000002"
         name: "Char with a Scene"
         displayName: "B"
 viewpoints:
     -
-        owner_id: 2
+        owner_id: "10000000-0000-0000-0000-000000000002"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"


### PR DESCRIPTION
This patch introduces a bunch of changes to help making graceful recovery from a failed module registration:
- Removed save-call from event registering and replaced with persisting
- Put registering calls between beginTransaction/commit/rollBack calls from doctrine to roll any changes back
- Added tests to make this behaviour required from now on
- To help with common registrations of users/scenes that rely in early flushes to get the new id, those ids have now been replaced with a randomly generated uuid. This is a huge BC break, but helps any module applying changes.

This pull request superseeds #118 