### PR TITLE
Improves upon the Attachment-Feature

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -25,6 +25,11 @@ abstract class Attachment implements AttachmentInterface
         $this->id = \bin2hex(\random_bytes(8));
     }
 
+    public function __toString(): string
+    {
+        return "<Attachment#{$this->id} '{". static::class . "}'>";
+    }
+
     /**
      * Returns an unique identifier for this attachment. Each attachment instance
      * will have its own unique ID, assigned at time of the instantiation.

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -3,22 +3,25 @@ declare(strict_types=1);
 
 namespace LotGD\Core;
 
+use Exception;
+use LotGD\Core\Models\Scene;
+
 /**
  * An attachment to a scene. This is desigend to be subclasses by modules to
  * provide functinoality like forms or maybe image attachments to go along with a scene.
  */
-abstract class Attachment
+abstract class Attachment implements AttachmentInterface
 {
     protected string $id;
 
     /**
      * Construct a new attachment of the given type. Randomly assigns it an ID.
-     * @param string $type Type of this attachment, in the vendor/module/type format.
-     * @return Attachment
+     * @param Game $game
+     * @param Scene $scene
+     * @throws Exception
      */
-    public function __construct(
-        protected string $type
-    ) {
+    public function __construct(Game $game, Scene $scene)
+    {
         $this->id = \bin2hex(\random_bytes(8));
     }
 
@@ -30,14 +33,5 @@ abstract class Attachment
     public function getId(): string
     {
         return $this->id;
-    }
-
-    /**
-     * Returns the type of this attachment, in vendor/module/type format.
-     * @return string
-     */
-    public function getType(): string
-    {
-        return $this->type;
     }
 }

--- a/src/AttachmentInterface.php
+++ b/src/AttachmentInterface.php
@@ -21,9 +21,4 @@ interface AttachmentInterface
      * @return array
      */
     public function getData(): array;
-
-    /**
-     * @return Action[]
-     */
-    public function getActions(): array;
 }

--- a/src/AttachmentInterface.php
+++ b/src/AttachmentInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core;
+
+use LotGD\Core\Models\Scene;
+
+interface AttachmentInterface
+{
+    /**
+     * AttachmentInterface constructor.
+     * @param Game $g Should not be saved internally.
+     * @param Scene $scene Should not be saved internally.
+     */
+    public function __construct(Game $g, Scene $scene);
+    public function getId(): string;
+
+    /**
+     * Returns an array with attachment-specific fields.
+     * @return array
+     */
+    public function getData(): array;
+
+    /**
+     * @return Action[]
+     */
+    public function getActions(): array;
+}

--- a/src/AttachmentInterface.php
+++ b/src/AttachmentInterface.php
@@ -13,6 +13,7 @@ interface AttachmentInterface
      * @param Scene $scene Should not be saved internally.
      */
     public function __construct(Game $g, Scene $scene);
+    public function __toString(): string;
     public function getId(): string;
 
     /**

--- a/src/Game.php
+++ b/src/Game.php
@@ -353,11 +353,6 @@ class Game
                 $attachment = new ($sceneAttachment->getClass())($this, $scene);
                 $viewpoint->addAttachment($attachment);
 
-                // Add attachment actions to the hidden group.
-                foreach ($attachment->getActions() as $action) {
-                    $actionGroups[ActionGroup::HiddenGroup]->addAction($action);
-                }
-
                 $this->getLogger()->debug("Adding attachment {$attachment}");
             }
 

--- a/src/Game.php
+++ b/src/Game.php
@@ -342,13 +342,30 @@ class Game
                 }
             });
 
+            // Create hidden group
+            $actionGroups[ActionGroup::HiddenGroup] = new ActionGroup(ActionGroup::HiddenGroup, '', 100);
+
+            // Iterates over all SceneAttachments and creates the corresponding attachment objects, adding them to the
+            // viewpoint. Additionally, all actions from the Attachments are added here to the hidden ActionGroup.
+            $sceneAttachments = $scene->getSceneAttachments();
+            foreach ($sceneAttachments as $sceneAttachment) {
+                /** @var AttachmentInterface $attachment */
+                $attachment = new ($sceneAttachment->getClass())($this, $scene);
+                $viewpoint->addAttachment($attachment);
+
+                // Add attachment actions to the hidden group.
+                foreach ($attachment->getActions() as $action) {
+                    $actionGroups[ActionGroup::HiddenGroup]->addAction($action);
+                }
+
+                $this->getLogger()->debug("Adding attachment {$attachment}");
+            }
+
             // Logging
             $counts = \implode(", ", \array_map(function ($k, $v) {
                 return $k .\count($v);
             }, \array_keys($actionGroups), \array_values($actionGroups)));
             $this->getLogger()->debug("Total actions: {$counts}");
-
-            $actionGroups[ActionGroup::HiddenGroup] = new ActionGroup(ActionGroup::HiddenGroup, '', 100);
 
             $viewpoint->setActionGroups(\array_values($actionGroups));
 

--- a/src/Models/Scene.php
+++ b/src/Models/Scene.php
@@ -425,7 +425,7 @@ class Scene implements CreateableInterface, SceneConnectable
     /**
      * @return Collection
      */
-    public function getAttachments(): Collection
+    public function getSceneAttachments(): Collection
     {
         return $this->attachments;
     }
@@ -434,7 +434,7 @@ class Scene implements CreateableInterface, SceneConnectable
      * @param SceneAttachment $sceneAttachment
      * @return bool
      */
-    public function hasAttachment(SceneAttachment $sceneAttachment): bool
+    public function hasSceneAttachment(SceneAttachment $sceneAttachment): bool
     {
         return $this->attachments->contains($sceneAttachment);
     }
@@ -442,9 +442,9 @@ class Scene implements CreateableInterface, SceneConnectable
     /**
      * @param SceneAttachment $attachmentClass
      */
-    public function addAttachment(SceneAttachment $attachmentClass): void
+    public function addSceneAttachment(SceneAttachment $attachmentClass): void
     {
-        if (!$this->hasAttachment($attachmentClass)) {
+        if (!$this->hasSceneAttachment($attachmentClass)) {
             $this->attachments->add($attachmentClass);
         }
     }

--- a/src/Models/SceneAttachment.php
+++ b/src/Models/SceneAttachment.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Attachment;
 use LotGD\Core\AttachmentInterface;
 use LotGD\Core\Exceptions\ArgumentException;
+use LotGD\Core\Tools\Model\UserAssignable;
 
 /**
  * A SceneAttachment is a registered Attachment class to keep track of
@@ -23,6 +24,8 @@ use LotGD\Core\Exceptions\ArgumentException;
  */
 class SceneAttachment
 {
+    use UserAssignable;
+
     /**
      * @Id
      * @Column(type="string", length=36, unique=True, name="class", options={"fixed"=true})
@@ -39,15 +42,17 @@ class SceneAttachment
      * SceneAttachment constructor.
      * @param string $class A class inheriting from AttachmentInterface.
      * @param string $title
+     * @param bool $userAssignable
      * @throws ArgumentException if $class does not implement AttachmentInterface
      */
-    public function __construct(string $class, string $title) {
+    public function __construct(string $class, string $title, bool $userAssignable = true) {
         if (!is_subclass_of($class, AttachmentInterface::class)) {
             throw new ArgumentException("The class '{$class}' must inherit from " . AttachmentInterface::class);
         }
 
         $this->class = $class;
         $this->title = $title;
+        $this->setUserAssignable($userAssignable);
 
         $this->scenes = new ArrayCollection();
     }

--- a/src/Models/SceneAttachment.php
+++ b/src/Models/SceneAttachment.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Models;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\Table;
+use LotGD\Core\Attachment;
+use LotGD\Core\Exceptions\ArgumentException;
+
+/**
+ * A SceneAttachment is a registered Attachment class to keep track of
+ * (a) generally all available attachments, and
+ * (b) which scene contains which attachment.
+ * @Entity
+ * @Table(name="scene_attachments")
+ */
+class SceneAttachment
+{
+    /**
+     * @Id
+     * @Column(type="string", length=36, unique=True, name="class", options={"fixed"=true})
+     */
+    protected string $class;
+
+    /** @Column(type="string", length=255) */
+    protected string $title;
+
+    /** @ManyToMany(targetEntity="Scene", mappedBy="attachments")  */
+    private ?Collection $scenes;
+
+    /**
+     * SceneAttachment constructor.
+     * @param string $class A class inheriting from Attachment.
+     * @param string $title
+     * @throws ArgumentException if $class does not implement Attachment
+     */
+    public function __construct(string $class, string $title) {
+        if (!is_subclass_of($class, Attachment::class)) {
+            throw new ArgumentException("The class '{$class}' must inherit from " . Attachment::class);
+        }
+
+        $this->class = $class;
+        $this->title = $title;
+
+        $this->scenes = new ArrayCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getScenes(): Collection
+    {
+        return $this->scenes;
+    }
+}

--- a/src/Models/SceneAttachment.php
+++ b/src/Models/SceneAttachment.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Attachment;
+use LotGD\Core\AttachmentInterface;
 use LotGD\Core\Exceptions\ArgumentException;
 
 /**
@@ -36,13 +37,13 @@ class SceneAttachment
 
     /**
      * SceneAttachment constructor.
-     * @param string $class A class inheriting from Attachment.
+     * @param string $class A class inheriting from AttachmentInterface.
      * @param string $title
-     * @throws ArgumentException if $class does not implement Attachment
+     * @throws ArgumentException if $class does not implement AttachmentInterface
      */
     public function __construct(string $class, string $title) {
-        if (!is_subclass_of($class, Attachment::class)) {
-            throw new ArgumentException("The class '{$class}' must inherit from " . Attachment::class);
+        if (!is_subclass_of($class, AttachmentInterface::class)) {
+            throw new ArgumentException("The class '{$class}' must inherit from " . AttachmentInterface::class);
         }
 
         $this->class = $class;

--- a/src/Models/SceneTemplate.php
+++ b/src/Models/SceneTemplate.php
@@ -7,10 +7,12 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Exceptions\ClassNotFoundException;
 use LotGD\Core\SceneTemplates\SceneTemplateInterface;
+use LotGD\Core\Tools\Model\UserAssignable;
 
 /**
  * Class SceneTemplates.
@@ -19,14 +21,13 @@ use LotGD\Core\SceneTemplates\SceneTemplateInterface;
  */
 class SceneTemplate
 {
+    use UserAssignable;
+
     /** @Id @Column(type="string", length=255, unique=True, name="class") */
     protected string $class;
 
     /** @Column(type="string", length=255, name="module") */
     protected string $module;
-
-    /** @Column(type="boolean", options={"default"=true}) */
-    protected bool $userAssignable = true;
 
     /**
      * @OneToMany(targetEntity="Scene", mappedBy="template")
@@ -44,10 +45,11 @@ class SceneTemplate
      * SceneTemplates constructor.
      * @param string $class FQCN of the scene handling class.
      * @param string $module Module from where the class is from.
-     * @throws ClassNotFoundException
+     * @param bool $userAssignable Set to false to flag the scene as not-assignable for the user.
      * @throws ArgumentException
+     * @throws ClassNotFoundException
      */
-    public function __construct(string $class, string $module)
+    public function __construct(string $class, string $module, bool $userAssignable = true)
     {
         if (!\class_exists($class)) {
             throw new ClassNotFoundException("The class {$class} cannot be found.");
@@ -57,6 +59,7 @@ class SceneTemplate
 
         $this->class = $class;
         $this->module = $module;
+        $this->setUserAssignable($userAssignable);
     }
 
     /**

--- a/src/Models/Viewpoint.php
+++ b/src/Models/Viewpoint.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Table;
 use LotGD\Core\Action;
 use LotGD\Core\ActionGroup;
 use LotGD\Core\Attachment;
+use LotGD\Core\AttachmentInterface;
 use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Game;
 use LotGD\Core\Services\TwigSceneRenderer;
@@ -281,7 +282,7 @@ class Viewpoint implements CreateableInterface
 
     /**
      * Returns all attachments.
-     * @return array
+     * @return AttachmentInterface[]
      */
     public function getAttachments(): array
     {
@@ -290,7 +291,7 @@ class Viewpoint implements CreateableInterface
 
     /**
      * Sets attachments.
-     * @param Attachment[] $attachments
+     * @param AttachmentInterface[] $attachments
      */
     public function setAttachments(array $attachments)
     {
@@ -299,8 +300,9 @@ class Viewpoint implements CreateableInterface
 
     /**
      * Adds an attachment
+     * @param AttachmentInterface $attachment
      */
-    public function addAttachment(Attachment $attachment)
+    public function addAttachment(AttachmentInterface $attachment)
     {
         $this->attachments[] = $attachment;
     }

--- a/src/Tools/Model/Creator.php
+++ b/src/Tools/Model/Creator.php
@@ -18,9 +18,9 @@ trait Creator
     /**
      * Creates and returns an entity instance and fills values.
      * @param array $arguments The values the instance should get
-     * @throws AttributeMissingException
-     * @throws WrongTypeException
      * @return CreateableInterface The created Entity
+     * @throws WrongTypeException|UnexpectedArrayKeyException
+     * @throws AttributeMissingException
      */
     public static function create(array $arguments): CreateableInterface
     {

--- a/src/Tools/Model/SceneBasics.php
+++ b/src/Tools/Model/SceneBasics.php
@@ -17,7 +17,7 @@ trait SceneBasics
     private string $title = "{No scene set}";
     /** @Column(type="text") */
     private string $description = "{No scene set}";
-    /** @Column(type="string", length=255) */
+
     /**
      * @ManyToOne(targetEntity="SceneTemplate", fetch="EAGER")
      * @JoinColumn(name="template", referencedColumnName="class", nullable=true)

--- a/src/Tools/Model/UserAssignable.php
+++ b/src/Tools/Model/UserAssignable.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tools\Model;
+
+use Doctrine\ORM\Mapping\Column;
+
+trait UserAssignable
+{
+    /** @Column(type="boolean", options={"default"=true}) */
+    protected bool $userAssignable = true;
+
+    /**
+     * Changes whether the template should be able to get manually assigned to a template or not.
+     * @param bool $flag
+     */
+    public function setUserAssignable(bool $flag = true)
+    {
+        $this->userAssignable = $flag;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUserAssignable(): bool
+    {
+        return $this->userAssignable;
+    }
+}

--- a/tests/Models/SceneAttachmentTest.php
+++ b/tests/Models/SceneAttachmentTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD\Core\Tests\Models;
+
+use LotGD\Core\Attachment;
+use LotGD\Core\Exceptions\ArgumentException;
+use LotGD\Core\Models\{Scene, SceneAttachment, SceneConnection, SceneConnectionGroup, SceneTemplate};
+use LotGD\Core\Tests\CoreModelTestCase;
+use LotGD\Core\Tests\SceneTemplates\NewSceneSceneTemplate;
+
+class TestAttachment extends Attachment
+{
+
+}
+
+class InvalidTestAttachment
+{
+
+}
+
+/**
+ * Tests for creating scenes and moving them around.
+ */
+class SceneAttachmentTest extends CoreModelTestCase
+{
+    /** @var string default data set */
+    protected $dataset = "scene";
+
+    public function testSceneAttachmentCreationWithValidParameters()
+    {
+        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment");
+
+        $this->assertInstanceOf(SceneAttachment::class, $sceneAttachment);
+    }
+
+    public function testIfSceneAttachmentCreationFailsIfAttachmentIsNotSubclassOfAttachment()
+    {
+        $this->expectException(ArgumentException::class);
+
+        $sceneAttachment = new SceneAttachment(InvalidTestAttachment::class, "Invalid Test Attachment");
+    }
+
+    public function testIfValidSceneAttachmentCanBePersistedAndGottenBackFromTheDatabase()
+    {
+        $em = $this->getEntityManager();
+        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment");
+
+        // persist
+        $em->persist($sceneAttachment);
+        $em->flush();
+        $em->clear();
+
+        // retrieve
+        $retrievedSceneAttachment = $em->getRepository(SceneAttachment::class)->find(TestAttachment::class);
+
+        $this->assertInstanceOf(SceneAttachment::class, $retrievedSceneAttachment);
+
+        // Delete again
+        $em->remove($retrievedSceneAttachment);
+        $em->flush();
+    }
+
+    public function testIfSceneGettersReturnGivenValuesProperly()
+    {
+        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment");
+
+        $this->assertSame($sceneAttachment->getClass(), TestAttachment::class);
+        $this->assertSame($sceneAttachment->getTitle(), "Test Attachment");
+    }
+
+    public function testIfPersistingASceneAlsoPersistsASceneAttachment()
+    {
+        $em = $this->getEntityManager();
+
+        $scene = new Scene("Test scene", "A test scene");
+        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment");
+
+        $scene->addAttachment($sceneAttachment);
+        $sceneId = $scene->getId();
+
+        // persist
+        $em->persist($scene);
+        $em->flush();
+        $em->clear();
+
+        // retrieve
+        $retrievedSceneAttachment = $em->getRepository(SceneAttachment::class)->find(TestAttachment::class);
+
+        // assert
+        $this->assertInstanceOf(SceneAttachment::class, $retrievedSceneAttachment);
+        $this->assertCount(1, $retrievedSceneAttachment->getScenes());
+
+        // remove scene
+        $scene = $retrievedSceneAttachment->getScenes()[0];
+        $em->remove($scene);
+        $em->flush();
+        $em->clear();
+
+        // retrieve
+        $retrievedSceneAttachment = $em->getRepository(SceneAttachment::class)->find(TestAttachment::class);
+
+        // assert
+        $this->assertInstanceOf(SceneAttachment::class, $retrievedSceneAttachment);
+        $this->assertCount(0, $retrievedSceneAttachment->getScenes());
+
+        // remove attachment
+        $em->remove($retrievedSceneAttachment);
+        $em->flush();
+        $em->clear();
+
+        // retrieve
+        $retrievedSceneAttachment = $em->getRepository(SceneAttachment::class)->find(TestAttachment::class);
+
+        // assert
+        $this->assertNull($retrievedSceneAttachment);
+    }
+}

--- a/tests/Models/SceneAttachmentTest.php
+++ b/tests/Models/SceneAttachmentTest.php
@@ -111,10 +111,12 @@ class SceneAttachmentTest extends CoreModelTestCase
         $em = $this->getEntityManager();
 
         $scene = new Scene("Test scene", "A test scene");
-        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment");
+        $sceneAttachment = new SceneAttachment(TestAttachment::class, "Test Attachment", userAssignable: false);
 
         $scene->addSceneAttachment($sceneAttachment);
         $sceneId = $scene->getId();
+
+        $this->assertFalse($sceneAttachment->isUserAssignable());
 
         // persist
         $em->persist($scene);
@@ -127,6 +129,7 @@ class SceneAttachmentTest extends CoreModelTestCase
         // assert
         $this->assertInstanceOf(SceneAttachment::class, $retrievedSceneAttachment);
         $this->assertCount(1, $retrievedSceneAttachment->getScenes());
+        $this->assertFalse($sceneAttachment->isUserAssignable());
 
         // remove scene
         $scene = $retrievedSceneAttachment->getScenes()[0];

--- a/tests/Models/SceneAttachmentTest.php
+++ b/tests/Models/SceneAttachmentTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace LotGD\Core\Tests\Models;
 
+use LotGD\Core\Action;
 use LotGD\Core\Attachment;
 use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Models\{Scene, SceneAttachment, SceneConnection, SceneConnectionGroup, SceneTemplate};
@@ -11,7 +12,15 @@ use LotGD\Core\Tests\SceneTemplates\NewSceneSceneTemplate;
 
 class TestAttachment extends Attachment
 {
+    public function getData(): array
+    {
+        return [];
+    }
 
+    public function getActions(): array
+    {
+        return [];
+    }
 }
 
 class InvalidTestAttachment

--- a/tests/Models/SceneAttachmentTest.php
+++ b/tests/Models/SceneAttachmentTest.php
@@ -184,7 +184,5 @@ class SceneAttachmentTest extends CoreModelTestCase
 
         $this->assertCount(1, $newViewpoint->getAttachments());
         $this->assertSame(TestAttachmentWithActions::$attachmentId, $newViewpoint->getAttachments()[0]->getId());
-        $this->assertCount(1, $newViewpoint->getActionGroups()[1]->getActions());
-        $this->assertSame(TestAttachmentWithActions::$actionId, $newViewpoint->getActionGroups()[1]->getActions()[0]->getId());
     }
 }

--- a/tests/Models/ViewpointTest.php
+++ b/tests/Models/ViewpointTest.php
@@ -6,6 +6,7 @@ namespace LotGD\Core\Tests\Models;
 use LotGD\Core\Action;
 use LotGD\Core\ActionGroup;
 use LotGD\Core\Attachment;
+use LotGD\Core\Game;
 use LotGD\Core\Models\Character;
 use LotGD\Core\Models\Viewpoint;
 use LotGD\Core\Models\Scene;
@@ -16,15 +17,25 @@ class SampleAttachment extends Attachment
 {
     protected $foo;
 
-    public function __construct(string $foo)
+    public function __construct(Game $game, Scene $scene, $testParam = null)
     {
-        parent::__construct('bar');
-        $this->foo = $foo;
+        parent::__construct($game, $scene);
+        $this->foo = $testParam;
     }
 
     public function getFoo()
     {
         return $this->foo;
+    }
+
+    public function getData(): array
+    {
+        return [];
+    }
+
+    public function getActions(): array
+    {
+        return [];
     }
 }
 
@@ -122,13 +133,14 @@ class ViewpointTest extends CoreModelTestCase
     public function testAttachments()
     {
         $em = $this->getEntityManager();
+        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
 
-        $a1 = new SampleAttachment('baz');
-        $a2 = new SampleAttachment('fiz');
+        $a1 = new SampleAttachment($this->g, $input->getScene(), "baz");
+        $a2 = new SampleAttachment($this->g, $input->getScene(), "fiz");
 
         $attachments = [$a1, $a2];
 
-        $input = $em->getRepository(Viewpoint::class)->find("10000000-0000-0000-0000-000000000002");
+
         $input->setAttachments($attachments);
         $input->save($em);
 

--- a/tests/datasets/scene-attachment.yml
+++ b/tests/datasets/scene-attachment.yml
@@ -1,0 +1,61 @@
+characters:
+    -
+        id: "10000000-0000-0000-0000-000000000001"
+        name: "Char without a Scene"
+        displayName: "A"
+    -
+        id: "10000000-0000-0000-0000-000000000002"
+        name: "Char with a Scene"
+        displayName: "B"
+viewpoints:
+    -
+        owner_id: "10000000-0000-0000-0000-000000000002"
+        scene_id: "30000000-0000-0000-0000-000000000001"
+        title: "The Village"
+        description: "This is the village."
+        template: "lotgd/tests/village"
+        data: "a:0:{}"
+        attachments: "a:0:{}"
+        actionGroups: "a:0:{}"
+scene_attachments:
+    -
+        class: "LotGD\\Core\\Tests\\Models\\TestAttachmentWithActions"
+        title: "Test Attachment With Actions"
+scenes:
+    -
+        id: "30000000-0000-0000-0000-000000000001"
+        title: "The Village"
+        description: "This is the village."
+        template: "lotgd/tests/village"
+    -
+        id: "30000000-0000-0000-0000-000000000002"
+        title: "The Forest"
+        description: "This is a very dangerous and dark forest"
+        template: "lotgd/tests/forest"
+    -
+        id: "30000000-0000-0000-0000-000000000003"
+        title: "The Weaponry"
+        description: "This is the place where you can buy awesome weapons"
+        template: "lotgd/tests/weaponry"
+
+    -
+        id: "30000000-0000-0000-0000-000000000004"
+        title: "Template-less scene"
+        description: "This scene does not have a template"
+scenes_x_scene_attachments:
+    -
+        scene_id: "30000000-0000-0000-0000-000000000002"
+        attachment_id: "LotGD\\Core\\Tests\\Models\\TestAttachmentWithActions"
+    -
+        scene_id: "30000000-0000-0000-0000-000000000004"
+        attachment_id: "LotGD\\Core\\Tests\\Models\\TestAttachmentWithActions"
+scene_connections:
+    -
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000002"
+    -
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000003"
+    -
+        outgoingScene: "30000000-0000-0000-0000-000000000001"
+        incomingScene: "30000000-0000-0000-0000-000000000004"

--- a/tests/datasets/scene-attachment.yml
+++ b/tests/datasets/scene-attachment.yml
@@ -21,6 +21,7 @@ scene_attachments:
     -
         class: "LotGD\\Core\\Tests\\Models\\TestAttachmentWithActions"
         title: "Test Attachment With Actions"
+        userAssignable: false
 scenes:
     -
         id: "30000000-0000-0000-0000-000000000001"

--- a/tests/datasets/viewpoints.yml
+++ b/tests/datasets/viewpoints.yml
@@ -10,6 +10,7 @@ characters:
 viewpoints:
     -
         owner_id: "10000000-0000-0000-0000-000000000002"
+        scene_id: "30000000-0000-0000-0000-000000000001"
         title: "The Village"
         description: "This is the village."
         template: "lotgd/tests/village"


### PR DESCRIPTION
A new model, called `SceneAttachment`, allows modules to save their attachment in a database table and can be assigned to scenes - either by the Module directly, or by the user if the `SceneAttachment` is marked like that. This way should be used primarily for non-interactive attachments that could be used by administrators, like an "ImageAttachment" or a "TableAttachment", or whatever. Temporary attachments, like a shop interface, should be marked as "not userAssignable", or not even registered there but instead be added directly to the Viewpoint.

The new `AttachmentInterface` (with a basis implementation by the abstract `Attachment`) calls for the Game-object and the Scene itself to help the Attachment creating the "data" parts.